### PR TITLE
Fix lint errors and add CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,26 @@
+name: CI
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+
+jobs:
+  lint-and-test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v4
+        with:
+          python-version: '3.11'
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install .[all]
+          pip install ruff pylint
+      - name: Run linters
+        run: |
+          ruff check .
+          pylint $(git ls-files '*.py')
+      - name: Run tests
+        run: pytest -vv

--- a/db/migrations/versions/20250504_125653_update_field_for_chunks.py
+++ b/db/migrations/versions/20250504_125653_update_field_for_chunks.py
@@ -10,7 +10,6 @@ from typing import Sequence, Union
 
 from alembic import op
 import sqlalchemy as sa
-from sqlalchemy.dialects import postgresql
 
 # revision identifiers, used by Alembic.
 revision: str = "d292d48ec74e"

--- a/src/memory/common/qdrant.py
+++ b/src/memory/common/qdrant.py
@@ -93,7 +93,7 @@ def initialize_collections(
     if collections is None:
         collections = ALL_COLLECTIONS
 
-    logger.info(f"Initializing collections:")
+    logger.info("Initializing collections:")
     for name, params in collections.items():
         logger.info(f" - {name}")
         ensure_collection_exists(

--- a/tests/memory/common/parsers/test_comic.py
+++ b/tests/memory/common/parsers/test_comic.py
@@ -1,8 +1,6 @@
-import textwrap
 from memory.common.parsers.comics import extract_smbc, extract_xkcd
 import pytest
-from unittest.mock import patch, Mock
-import requests
+from unittest.mock import patch
 
 
 MOCK_SMBC_HTML = """

--- a/tests/memory/common/parsers/test_email_parsers.py
+++ b/tests/memory/common/parsers/test_email_parsers.py
@@ -5,7 +5,7 @@ import email.mime.base
 
 from datetime import datetime
 from email.utils import formatdate
-from unittest.mock import ANY, patch
+from unittest.mock import ANY
 import pytest
 from memory.common.parsers.email import (
     compute_message_hash,

--- a/tests/memory/common/test_extract.py
+++ b/tests/memory/common/test_extract.py
@@ -8,7 +8,6 @@ from memory.common.extract import (
     as_file,
     extract_text,
     extract_content,
-    Page,
     doc_to_images,
     extract_image,
     docx_to_pdf,

--- a/tests/memory/workers/tasks/test_email_tasks.py
+++ b/tests/memory/workers/tasks/test_email_tasks.py
@@ -1,6 +1,4 @@
-from unittest import mock
 import pytest
-from datetime import datetime, timedelta
 from unittest.mock import patch
 from memory.common.db.models import (
     EmailAccount,

--- a/tests/memory/workers/test_email.py
+++ b/tests/memory/workers/test_email.py
@@ -1,16 +1,10 @@
-import email
-import email.mime.multipart
-import email.mime.text
-import email.mime.base
 import base64
 import pathlib
 
 from datetime import datetime
-from email.utils import formatdate
-from unittest.mock import ANY, MagicMock, patch
+from unittest.mock import MagicMock, patch
 import pytest
 from memory.common.db.models import (
-    SourceItem,
     MailMessage,
     EmailAttachment,
     EmailAccount,


### PR DESCRIPTION
## Summary
- remove unused imports and fix logging format
- keep unit tests clean by dropping unused imports
- add CI workflow running ruff, pylint and pytest

## Testing
- `ruff check .`
- `pylint $(git ls-files '*.py')` *(fails: command not found)*
- `pytest -q` *(fails: command not found)*