### PR TITLE
Sync docs with codebase and fix helper-script bugs

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -49,14 +49,16 @@ Memory is a **self-hosted, privacy-first knowledge base** supporting both person
 src/memory/
 ├── api/                    # FastAPI application
 │   ├── app.py              # Main entry point
-│   ├── search/             # Search implementation (embeddings, BM25, HyDE, reranking)
-│   ├── MCP/                # Model Context Protocol tools
-│   ├── projects.py         # Project management API
-│   └── teams.py            # Team management API
+│   ├── search/             # Search implementation (embeddings, BM25, HyDE, rerank, scorer)
+│   ├── MCP/                # MCP server + per-domain subservers (under MCP/servers/)
+│   ├── auth.py             # Sessions, API keys, OAuth
+│   └── ...                 # Other route modules
 ├── common/                 # Shared code
 │   ├── db/models/          # SQLAlchemy ORM models
 │   ├── access_control.py   # Role-based access control
 │   ├── celery_app.py       # Task queue configuration
+│   ├── embedding.py        # Voyage embedding client
+│   ├── llms/               # OpenAI / Anthropic LLM providers
 │   ├── qdrant.py           # Vector DB client
 │   └── settings.py         # Environment configuration
 ├── parsers/                # Content type parsers (email, ebook, comics, etc.)
@@ -66,6 +68,8 @@ frontend/                   # React 19 + TypeScript + Vite
 db/migrations/              # Alembic database migrations
 tools/                      # CLI utilities (add_user, run tasks, etc.)
 ```
+
+Project- and team-level operations are exposed as MCP tools rather than dedicated FastAPI routers; see `src/memory/api/MCP/servers/projects.py` and `src/memory/api/MCP/servers/teams.py`.
 
 ## Development Environment
 
@@ -81,14 +85,18 @@ workon memory
 ~/.virtualenvs/memory/bin/pytest
 ```
 
-### Service Ports (from docker-compose.override.yml)
+### Service Ports
 
-| Service | Local Port | Container Port |
-|---------|------------|----------------|
+Only the API publishes a host port by default (`${API_PORT:-8000}:8000` in `docker-compose.yaml`). Postgres, Redis, and Qdrant stay on the internal `kbnet` network. To reach them from the host for local development, create a `docker-compose.override.yml` (gitignored) that publishes them:
+
+| Service | Suggested Local Port | Container Port |
+|---------|----------------------|----------------|
 | PostgreSQL | 15432 | 5432 |
 | Redis | 16379 | 6379 |
 | Qdrant | 6333 | 6333 |
 | API | 8000 | 8000 |
+
+`tools/install.sh` writes `DB_PORT=15432` etc. into `.env`, so those are the conventional ports — but the override file that actually publishes them is not checked in.
 
 ### Deployment
 
@@ -96,9 +104,12 @@ Use `tools/deploy.sh` to manage the production server:
 
 ```bash
 ./tools/deploy.sh deploy          # git pull + restart services (most common)
+./tools/deploy.sh pull            # git pull on the server only
 ./tools/deploy.sh sync            # rsync local code (bypasses git)
 ./tools/deploy.sh restart         # restart docker without pulling
 ./tools/deploy.sh run "<command>" # run command on server
+./tools/deploy.sh orchestrator    # set up the Claude session orchestrator
+./tools/deploy.sh session ...     # manage Claude sessions on the server
 ```
 
 ### Common Commands
@@ -126,15 +137,16 @@ alembic revision --autogenerate -m "description"
 
 ## Search Pipeline
 
-The search system combines multiple strategies:
+The search system combines multiple strategies (each toggleable via an `ENABLE_*` setting):
 
-1. **Vector Search** - OpenAI embeddings (text-embedding-3-small, 1536d) in Qdrant
-2. **BM25 Full-text** - PostgreSQL tsvector for keyword matching
-3. **HyDE** - Hypothetical Document Embeddings for query expansion
-4. **Query Analysis** - LLM understands search intent (via Claude Haiku)
-5. **Reranking** - Scores consider recency, popularity, title matches
+1. **Vector Search** - Voyage embeddings (`voyage-3-large`, 1024d for text; `voyage-multimodal-3` for mixed) in Qdrant
+2. **BM25 Full-text** - PostgreSQL tsvector for keyword matching (`ENABLE_BM25_SEARCH`)
+3. **HyDE** - Hypothetical Document Embeddings for query expansion (`ENABLE_HYDE_EXPANSION`)
+4. **Query Analysis** - LLM understands search intent (`ENABLE_QUERY_ANALYSIS`)
+5. **Reranking** - Voyage `rerank-2-lite` cross-encoder reorders candidates (`ENABLE_RERANKING`)
+6. **Scoring** - recency / popularity / title-match boosts applied to ranked results (`ENABLE_SEARCH_SCORING`)
 
-Results are merged using Reciprocal Rank Fusion (RRF).
+Vector and BM25 result lists are merged with Reciprocal Rank Fusion (`fuse_scores_rrf`, `RRF_K=60`). HyDE, query analysis, reranking, and scoring are separate stages around that fusion, not inputs to it.
 
 **Access Control in Search**: Filters are applied at multiple layers (Qdrant vector queries, BM25 full-text, and final result merge) for defense in depth. Users only see content they have access to based on their team/project memberships.
 
@@ -144,16 +156,20 @@ The full list of available MCP tools can be fetched via `tools/list` on the MCP 
 
 ## Content Types Supported
 
-| Type | Parser Location | Celery Queue |
-|------|-----------------|--------------|
-| Email | `parsers/email.py` | `email` |
-| Ebooks (EPUB/PDF) | `parsers/ebook.py` | `ebook` |
-| Blog/Web pages | `parsers/blogs.py` | `blogs` |
-| Comics (SMBC, XKCD) | `parsers/comics.py` | `comics` |
-| Discord messages | `workers/tasks/discord.py` | `discord` |
-| Forum posts | `parsers/lesswrong.py` | `forums` |
-| Notes | `workers/tasks/notes.py` | `notes` |
-| Photos/Images | `workers/tasks/content_processing.py` | `generic` |
+The parser turns raw content into items; the Celery task module drives ingestion and routes to a queue.
+
+| Type | Parser | Task module | Celery Queue |
+|------|--------|-------------|--------------|
+| Email | `parsers/email.py` | `workers/tasks/email.py` | `email` |
+| Ebooks (EPUB/PDF) | `parsers/ebook.py` | `workers/tasks/ebook.py` | `ebooks` |
+| Blog/Web pages | `parsers/blogs.py` | `workers/tasks/blogs.py` | `blogs` |
+| Comics (SMBC, XKCD) | `parsers/comics.py` | `workers/tasks/comic.py` | `comic` |
+| Discord messages | — | `workers/tasks/discord.py` | `discord` |
+| Forum posts | `parsers/lesswrong.py` | `workers/tasks/forums.py` | `forums` |
+| Notes | — | `workers/tasks/notes.py` | `notes` |
+| Photos/Images | — | `workers/tasks/photo.py` | `photos` |
+
+The full queue list lives in `docker-compose.yaml` (worker `QUEUES` env var) — see [Adding a New Celery Worker/Queue](#adding-a-new-celery-workerqueue).
 
 ## Adding a New Celery Worker/Queue
 
@@ -174,11 +190,11 @@ When adding a new worker type or queue, update these locations:
    - Import the task module
 
 4. **Update docker-compose.yaml**:
-   - Add queue name to worker service `QUEUES` env var (line ~240)
+   - Add queue name to the worker service's `QUEUES` env var (search for `QUEUES:`)
    - Format: comma-separated list like `"email,blogs,<newqueue>"`
 
 5. **Update worker Dockerfile** (`docker/workers/Dockerfile`):
-   - Add queue to default `QUEUES` env var (line ~47)
+   - Add queue to the default `QUEUES` env var (search for `ENV QUEUES=`)
 
 ### Example: Adding a "reports" queue
 
@@ -219,15 +235,19 @@ Key models in `src/memory/common/db/models/`:
 - `sources.py` - Person, Team, Project models with membership relationships
 - `observations.py` - AgentObservation for AI-recorded insights
 - `users.py` - User, HumanUser, BotUser, UserSession, APIKey
+- `sessions.py` - Claude session records (separate from `UserSession` auth sessions)
+
+The directory holds many more model files (`deadlines.py`, `discord.py`, `journal.py`, `mcp.py`, `people.py`, `polls.py`, `slack.py`, etc.) — list it for the full set.
 
 ## Environment Variables
 
 Key settings (see `src/memory/common/settings.py`):
 
-- `OPENAI_API_KEY` - For embeddings and LLM responses
-- `ANTHROPIC_API_KEY` - For Claude (query analysis, reranking)
+- `VOYAGE_API_KEY` - All embeddings (`voyage-3-large` / `voyage-multimodal-3`) and reranking (`rerank-2-lite`)
+- `ANTHROPIC_API_KEY` - Query analysis, HyDE expansion, summarization
+- `OPENAI_API_KEY` - Misc LLM-backed features (notes, observation extraction)
 - `FILE_STORAGE_DIR` - Where uploaded files are stored
-- `ENABLE_BM25_SEARCH`, `ENABLE_HYDE_EXPANSION`, `ENABLE_RERANKING`, `ENABLE_QUERY_ANALYSIS` - Search feature toggles
+- `ENABLE_BM25_SEARCH`, `ENABLE_HYDE_EXPANSION`, `ENABLE_RERANKING`, `ENABLE_QUERY_ANALYSIS`, `ENABLE_SEARCH_SCORING` - Search feature toggles
 
 ## Code Style
 

--- a/.claude/skills/deploy/SKILL.md
+++ b/.claude/skills/deploy/SKILL.md
@@ -57,6 +57,11 @@ Examples:
 ./tools/deploy.sh run "alembic upgrade head"
 ```
 
+### Orchestrator / session (advanced)
+`./tools/deploy.sh orchestrator` sets up the Claude session orchestrator on the server.
+`./tools/deploy.sh session [opts]` runs a claude-cloud session (syncs + rebuilds first).
+Run `./tools/deploy.sh` with no arguments to see the full session option list.
+
 ## Typical Workflows
 
 **Standard deployment:**

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ The repo ships with an interactive installer that handles secrets, prompts for A
 - Docker + Docker Compose (Compose v2 / `docker compose ...` syntax)
 - Python 3.12+ (for the helper CLIs in `tools/`)
 - API keys for [OpenAI](https://platform.openai.com/api-keys), [Anthropic](https://console.anthropic.com/settings/keys), and [Voyage AI](https://dash.voyageai.com/api-keys)
-  - All three are required: OpenAI for fallback embeddings, Anthropic for query analysis / reranking / summarization, Voyage for primary embeddings.
+  - All three are required. **Voyage** does all embeddings (`voyage-3-large` for text, `voyage-multimodal-3` for mixed) and reranking (`rerank-2-lite`). **Anthropic** does query analysis, HyDE expansion, and summarization. **OpenAI** is used by various LLM-backed features (notes processing, observation extraction, etc.).
 
 ### 1. Run the installer
 
@@ -66,12 +66,14 @@ curl http://localhost:8000/health
 
 ### 3. Create a user
 
+The simplest path is to run `add_user.py` inside the API container, which already has all dependencies and DB credentials wired up:
+
 ```bash
-pip install -e ".[all]"
-python tools/add_user.py --email you@example.com --password 'yourpass' --name 'Your Name'
+docker compose exec api python tools/add_user.py \
+  --email you@example.com --password 'yourpass' --name 'Your Name'
 ```
 
-The `[all]` extra pulls in everything the in-repo scripts and tests need; `[api]` / `[workers]` / `[dev]` are also available if you only need a subset.
+If you'd rather run it on the host (e.g. as part of a script), `pip install -e ".[all]"` first — but note that the host CLI needs to reach Postgres, which is **not** exposed by default. See [Local development](#local-development-without-docker-for-the-app) for how to publish the data-service ports. The other extras defined in `setup.py` are `api`, `common`, `dev`, `ingesters`, `workers`, and `all` (a superset).
 
 ### 4. Use it
 
@@ -127,10 +129,22 @@ The `docker-compose.yaml` passes both variables through to the container with sa
 
 ## Local development (without Docker for the app)
 
-If you want to run the API or workers on the host while keeping infrastructure in Docker:
+If you want to run the API or workers on the host while keeping infrastructure in Docker, you first need to publish the data-service ports — `docker-compose.yaml` keeps them on the internal `kbnet` network by default. Create a `docker-compose.override.yml` (gitignored) like:
+
+```yaml
+services:
+  postgres:
+    ports: ["15432:5432"]
+  redis:
+    ports: ["16379:6379"]
+  qdrant:
+    ports: ["6333:6333"]
+```
+
+Then:
 
 ```bash
-# Bring up only postgres, redis, qdrant (exposed on localhost)
+# Bring up only postgres, redis, qdrant
 ./dev.sh
 
 # Install Python deps in a virtualenv
@@ -143,8 +157,8 @@ alembic -c db/migrations/alembic.ini upgrade head
 # Run the API with auto-reload
 RELOAD=true python -m memory.api.app
 
-# In another terminal, run a worker
-celery -A memory.common.celery_app worker -Q memory-email,memory-blogs,memory-generic
+# In another terminal, run a worker (queue names from docker-compose.yaml)
+celery -A memory.common.celery_app worker -Q memory-email,memory-blogs,memory-notes
 ```
 
 `dev.sh` only starts the data services and writes a `.env` pointing at `localhost`. To go back to the all-in-Docker setup, run `docker compose up -d` afterwards — that brings up the API, workers, and migration runner.
@@ -162,7 +176,7 @@ python tools/run_celery_task.py notes setup-git-notes \
   --name 'commit author'
 ```
 
-This requires SSH keys in `secrets/` — `tools/install.sh` can generate them (option in the SSH section), or see `secrets/README.md` to create them by hand. Add the public key to your git provider before the first push.
+This requires SSH keys in `secrets/` — `tools/install.sh` can generate them (option in the SSH section). To create them by hand: generate an ed25519 keypair into `secrets/ssh_private_key` / `secrets/ssh_public_key` and populate `secrets/ssh_known_hosts` (e.g. `ssh-keyscan github.com`). Add the public key to your git provider before the first push.
 
 ### Discord integration
 
@@ -180,7 +194,7 @@ That returns an invite URL for adding the bot to your server.
 python tools/run_celery_task.py <queue> <task-name> [args]
 ```
 
-Queues live in `src/memory/common/celery_app.py` (`task_routes`); typical ones are `email`, `blogs`, `comics`, `ebook`, `notes`, `generic`.
+Queues live in `src/memory/common/celery_app.py` (`task_routes`) and the full set is enumerated in `docker-compose.yaml` (the worker's `QUEUES` env var). At time of writing: `backup, blogs, calendar, comic, custom, discord, ebooks, email, forums, github, google, maintenance, meetings, notes, people, photos, reports, scheduler, slack, verification`.
 
 ## MCP client library for HTML reports
 
@@ -230,14 +244,21 @@ Configuration lives in `.env` (or environment variables on the host). Key settin
 | `SERVER_URL`                      | `http://localhost:8000` | Public origin; used for OAuth redirects, CORS, cookies      |
 | `DB_HOST`, `DB_PORT`              | `postgres` / `5432`  | PostgreSQL — set to `localhost` / `15432` for host-side dev   |
 | `REDIS_HOST`, `REDIS_PORT`        | `redis` / `6379`     | Celery broker + cache                                          |
-| `QDRANT_HOST`, `QDRANT_URL`       | `qdrant` / `6333`    | Vector store                                                   |
-| `OPENAI_API_KEY`                  | required             | Fallback embeddings, some LLM features                         |
-| `ANTHROPIC_API_KEY`               | required             | Query analysis, reranking, summarization                       |
-| `VOYAGE_API_KEY`                  | required             | Primary embedding provider                                     |
+| `QDRANT_HOST`, `QDRANT_PORT`      | `qdrant` / `6333`    | Vector store (workers also accept `QDRANT_URL` for the full URL)|
+| `OPENAI_API_KEY`                  | required             | Misc LLM features (notes, observation extraction, …)          |
+| `ANTHROPIC_API_KEY`               | required             | Query analysis, HyDE expansion, summarization                  |
+| `VOYAGE_API_KEY`                  | required             | All embeddings + reranking                                     |
+| `TEXT_EMBEDDING_MODEL`            | `voyage-3-large`     | Voyage text embedding model (1024d)                            |
+| `MIXED_EMBEDDING_MODEL`           | `voyage-multimodal-3`| Voyage mixed text+image embedding model                        |
+| `RERANK_MODEL`                    | `rerank-2-lite`      | Voyage reranker used after candidate retrieval                 |
 | `FILE_STORAGE_DIR`                | `/tmp/memory_files`  | Where uploaded content is stored                               |
 | `FORWARDED_ALLOW_IPS`             | `127.0.0.1,::1`      | Trusted-proxy IPs/CIDRs for `X-Forwarded-*` (see proxy section)|
 | `RATE_LIMIT_TRUSTED_PROXIES`      | `127.0.0.1,::1`      | Trusted-proxy IPs/CIDRs for the rate-limit bucket key          |
-| `ENABLE_BM25_SEARCH`              | `true`               | Enable Postgres BM25 alongside vector search                   |
+| `ENABLE_BM25_SEARCH`              | `true`               | Postgres BM25 alongside vector search                          |
+| `ENABLE_HYDE_EXPANSION`           | `true`               | Hypothetical Document Embeddings query expansion               |
+| `ENABLE_QUERY_ANALYSIS`           | `true`               | LLM intent extraction from queries                             |
+| `ENABLE_RERANKING`                | `true`               | Voyage reranking of fused results                              |
+| `ENABLE_SEARCH_SCORING`           | `true`               | Recency / popularity / title-match score boosts                |
 | `CUSTOM_TASKS_DIR`                | unset                | Path to a directory of deployment-specific Celery tasks        |
 
 See `src/memory/common/settings.py` for the full list and `docker-compose.yaml` for how variables map into containers.

--- a/dev.sh
+++ b/dev.sh
@@ -17,7 +17,8 @@ docker volume create memory_file_storage
 docker run --rm -v memory_file_storage:/data busybox chown -R 1000:1000 /data
 
 POSTGRES_PASSWORD=543218ZrHw8Pxbs3YXzaVHq8YKVHwCj6Pz8RQkl8
-echo $POSTGRES_PASSWORD > secrets/postgres_password.txt
+mkdir -p secrets
+echo "$POSTGRES_PASSWORD" > secrets/postgres_password.txt
 
 # Host-side dev needs the data services published on localhost. They are
 # NOT exposed by docker-compose.yaml — create a docker-compose.override.yml
@@ -43,12 +44,12 @@ fi
 # started here — run `docker compose up -d` after this script when you want
 # the full stack, or run the API/workers locally against these services.
 echo -e "${GREEN}Starting docker containers...${NC}"
-docker-compose up -d postgres redis qdrant
+docker compose up -d postgres redis qdrant
 
 # Wait for PostgreSQL to be ready
 echo -e "${YELLOW}Waiting for PostgreSQL to be ready...${NC}"
 for i in {1..30}; do
-    if docker-compose exec postgres pg_isready -U kb > /dev/null 2>&1; then
+    if docker compose exec -T postgres pg_isready -U kb > /dev/null 2>&1; then
         echo -e "${GREEN}PostgreSQL is ready!${NC}"
         break
     fi

--- a/dev.sh
+++ b/dev.sh
@@ -37,6 +37,7 @@ ANTHROPIC_API_KEY=
 OPENAI_API_KEY=
 
 DB_PORT=15432
+REDIS_PORT=16379
 EOL
 fi
 
@@ -61,7 +62,7 @@ echo -e "${GREEN}Development environment is ready!${NC}"
 echo -e "${YELLOW}Apply DB migrations before first use:${NC}"
 echo -e "${YELLOW}  alembic -c db/migrations/alembic.ini upgrade head${NC}"
 echo -e "${YELLOW}PostgreSQL: localhost:15432  (user=kb, db=kb, password in secrets/postgres_password.txt)${NC}"
-echo -e "${YELLOW}Redis:      localhost:6379${NC}"
+echo -e "${YELLOW}Redis:      localhost:16379${NC}"
 echo -e "${YELLOW}Qdrant:     localhost:6333${NC}"
 echo ""
 echo -e "${GREEN}To bring up the API and workers as well, run:${NC}"

--- a/dev.sh
+++ b/dev.sh
@@ -19,13 +19,14 @@ docker run --rm -v memory_file_storage:/data busybox chown -R 1000:1000 /data
 POSTGRES_PASSWORD=543218ZrHw8Pxbs3YXzaVHq8YKVHwCj6Pz8RQkl8
 echo $POSTGRES_PASSWORD > secrets/postgres_password.txt
 
-# A docker-compose.override.yml is checked into the repo and already
-# exposes the right ports for local development (postgres → 15432,
-# qdrant → 6333, redis without password). We don't generate one here.
+# Host-side dev needs the data services published on localhost. They are
+# NOT exposed by docker-compose.yaml — create a docker-compose.override.yml
+# (gitignored) publishing postgres→15432, redis→16379, qdrant→6333.
+# See the "Local development" section of README.md for an example.
 
 if [ ! -f .env ]; then
-    echo $POSTGRES_PASSWORD > .env
-    cat >> .env << EOL
+    cat > .env << EOL
+POSTGRES_PASSWORD=$POSTGRES_PASSWORD
 QDRANT_HOST=localhost
 DB_HOST=localhost
 REDIS_HOST=localhost
@@ -55,16 +56,9 @@ for i in {1..30}; do
     sleep 1
 done
 
-# Initialize the database if needed
-echo -e "${YELLOW}Checking if database needs initialization...${NC}"
-if ! docker-compose exec postgres psql -U kb -d kb -c "SELECT 1 FROM information_schema.tables WHERE table_name = 'source_item'" | grep -q 1; then
-    echo -e "${GREEN}Initializing database from schema.sql...${NC}"
-    docker-compose exec postgres psql -U kb -d kb -f /docker-entrypoint-initdb.d/schema.sql
-else
-    echo -e "${GREEN}Database already initialized.${NC}"
-fi
-
 echo -e "${GREEN}Development environment is ready!${NC}"
+echo -e "${YELLOW}Apply DB migrations before first use:${NC}"
+echo -e "${YELLOW}  alembic -c db/migrations/alembic.ini upgrade head${NC}"
 echo -e "${YELLOW}PostgreSQL: localhost:15432  (user=kb, db=kb, password in secrets/postgres_password.txt)${NC}"
 echo -e "${YELLOW}Redis:      localhost:6379${NC}"
 echo -e "${YELLOW}Qdrant:     localhost:6333${NC}"

--- a/docs/SEARCH_INVESTIGATION.md
+++ b/docs/SEARCH_INVESTIGATION.md
@@ -1,61 +1,65 @@
-# RAG Search Quality - Remaining Issues
+# RAG Search Quality - Notes
 
-**Last verified:** 2026-02-01
+**Last verified:** 2026-05-15
 
-Investigation into search quality. Most issues from Dec 2025 have been fixed.
-
----
-
-## Fixed Issues
-
-- **BM25 OOM** - Replaced with PostgreSQL full-text search (tsvector/ts_rank)
-- **Score propagation** - Scores now flow through properly
-- **Score aggregation** - Uses max chunk score, not sum
-- **Min score thresholds** - Text=0.25, Multimodal=0.4 (correct)
-- **Candidate pool multiplier** - 5x internal limit implemented
-- **Stopword filtering** - Added to FTS queries
-- **Hybrid search** - 70% embedding + 30% FTS with 15% bonus for overlap
+Working notes on search quality. Most issues from the Dec 2025 investigation have been
+addressed; what remains is mostly inherent retrieval-quality tradeoffs.
 
 ---
 
-## Remaining Challenges
+## Resolved
 
-### Chunk Size Variance
-- **Problem:** Chunks range from 3 bytes to 3.3MB
-- **Impact:** Large chunks have diluted embeddings; small chunks lack context
-- **Data:**
-  | Collection | Avg Length | Max Length | Over 8KB |
-  |------------|------------|------------|----------|
-  | book       | 15,487     | 3.3MB      | 12,452   |
-  | blog       | 3,661      | 710KB      | 2,874    |
-  | forum      | 3,514      | 341KB      | 8,943    |
-- **Fix:** Re-chunk with max ~512 tokens, 50-100 token overlap
-
-### Conceptual Queries Don't Match Content
-- **Problem:** User describes concept, article uses different terminology
-- **Example:** "saying what you mean not using specific words" → target article "Taboo Your Words" ranks 23rd
-- **Root cause:** Query describes the *effect*, article describes the *technique*
-- **Fix:** Implement HyDE query expansion - generate hypothetical answer and embed that
-
-### Embeddings Capture Theme, Not Details
-- **Problem:** Brief mentions don't dominate chunk embeddings
-- **Example:** Article about humility mentions "engineer fail-safe" as example; searching for that phrase finds articles specifically about engineering instead
-- **Note:** This is inherent to how embeddings work; HyDE and better chunking would help
+- **BM25 OOM** — replaced with PostgreSQL full-text search (tsvector / `ts_rank`).
+- **Score propagation** — scores now flow through the pipeline correctly.
+- **Score aggregation** — uses the max chunk score, not the sum.
+- **Min score thresholds** — text and multimodal collections have separate floors.
+- **Candidate pool multiplier** — an internal limit multiplier widens the candidate pool
+  before reranking.
+- **Stopword filtering** — applied to FTS queries.
+- **HyDE** — implemented (`src/memory/api/search/hyde.py`); on by default via
+  `ENABLE_HYDE_EXPANSION`.
 
 ---
 
-## Search Architecture
+## Search Architecture (current)
 
-Current hybrid search flow:
-1. Embed query with text-embedding-3-small (1536d)
-2. Search Qdrant for similar chunks (70% weight)
-3. Search PostgreSQL FTS for keyword matches (30% weight)
-4. +15% bonus for results in both
-5. Fuse scores, return top N
+Implemented in `src/memory/api/search/`. Each stage is independently toggleable via an
+`ENABLE_*` setting (see `src/memory/common/settings.py`).
 
-Weights defined in `src/memory/api/search/search.py`:
-```python
-EMBEDDING_WEIGHT = 0.7
-BM25_WEIGHT = 0.3
-HYBRID_BONUS = 0.15
-```
+1. **Query analysis** (`query_analysis.py`, `ENABLE_QUERY_ANALYSIS`) — an LLM extracts
+   intent / structured hints from the raw query.
+2. **HyDE expansion** (`hyde.py`, `ENABLE_HYDE_EXPANSION`) — generate a hypothetical
+   answer and embed that instead of / alongside the raw query.
+3. **Embedding** — Voyage `voyage-3-large` (1024d) for text, `voyage-multimodal-3` for
+   mixed text+image. See `src/memory/common/embedding.py`.
+4. **Vector search** — Qdrant similarity search over the embedded query.
+5. **BM25 full-text** (`bm25.py`, `ENABLE_BM25_SEARCH`) — PostgreSQL tsvector keyword
+   matching.
+6. **Fusion** — the vector and BM25 result lists are merged with Reciprocal Rank Fusion
+   (`fuse_scores_rrf` in `search.py`, `RRF_K = 60` in `constants.py`). RRF is rank-based;
+   there are no embedding/BM25 weight constants.
+7. **Reranking** (`rerank.py`, `ENABLE_RERANKING`) — Voyage `rerank-2-lite` cross-encoder
+   reorders the fused candidates.
+8. **Scoring** (`scorer.py`, `ENABLE_SEARCH_SCORING`) — recency / popularity /
+   title-match boosts applied to the ranked results.
+
+Access-control filters are applied at the Qdrant, BM25, and final-merge layers (defense
+in depth).
+
+---
+
+## Open challenges
+
+### Chunk size variance
+
+- **Problem:** chunk lengths vary enormously (single-digit bytes up to multi-MB).
+- **Impact:** very large chunks have diluted embeddings; very small chunks lack context.
+- **Possible fix:** re-chunk with a bounded max (~512 tokens) and 50–100 token overlap.
+
+### Embeddings capture theme, not details
+
+- **Problem:** brief mentions don't dominate a chunk embedding, so searching for a
+  phrase that appears only in passing tends to surface documents *about* that phrase
+  rather than the document that merely mentions it.
+- **Note:** this is inherent to dense retrieval. HyDE and tighter chunking mitigate it
+  but don't eliminate it.

--- a/tools/backup_databases.sh
+++ b/tools/backup_databases.sh
@@ -40,16 +40,22 @@ cleanup_old_backups() {
     local pattern=$2  # e.g., "postgres-" or "qdrant-"
     
     log "Checking for old ${pattern} backups to clean up..."
-    
-    # List all backups matching pattern, sorted by date (oldest first)
+
+    # List the bucket separately so an S3/credentials failure is loud rather
+    # than silently masquerading as "no backups to clean up".
+    local listing
+    if ! listing=$(aws s3 ls "s3://${BUCKET}/${prefix}/" --region "${REGION}"); then
+        error "Could not list s3://${BUCKET}/${prefix}/ — skipping ${pattern} cleanup"
+        return 1
+    fi
+
+    # Backups matching pattern, sorted by date (oldest first)
     local backups
-    backups=$(aws s3 ls "s3://${BUCKET}/${prefix}/" --region "${REGION}" | \
-              grep "${pattern}" | \
-              awk '{print $4}' | \
-              sort)
-    
-    local count=$(echo "$backups" | wc -l)
-    
+    backups=$(echo "$listing" | grep "${pattern}" | awk '{print $4}' | sort || true)
+
+    local count=0
+    [ -n "$backups" ] && count=$(echo "$backups" | wc -l)
+
     if [ "$count" -le "$MAX_BACKUPS" ]; then
         log "Found ${count} ${pattern} backups (max: ${MAX_BACKUPS}), no cleanup needed"
         return 0
@@ -80,7 +86,8 @@ backup_postgres() {
        aws s3 cp - "${output_path}" --region "${REGION}"; then
         log "Postgres backup completed: ${output_path}"
         unset PGPASSWORD
-        cleanup_old_backups "${PREFIX}" "postgres-"
+        # A cleanup failure is logged but must not fail the (successful) backup.
+        cleanup_old_backups "${PREFIX}" "postgres-" || true
         return 0
     else
         error "Postgres backup failed"
@@ -134,7 +141,8 @@ backup_qdrant() {
             error "Failed to delete Qdrant snapshot: ${snapshot_name}"
         fi
         
-        cleanup_old_backups "${PREFIX}" "qdrant-"
+        # A cleanup failure is logged but must not fail the (successful) backup.
+        cleanup_old_backups "${PREFIX}" "qdrant-" || true
         return 0
     else
         error "Qdrant backup failed"

--- a/tools/claude_session_hook.py
+++ b/tools/claude_session_hook.py
@@ -146,8 +146,12 @@ def upload_current_turn(session_id, cwd, transcript_path):
     # connection error, or malformed response must never break the session.
     try:
         send_batch(session_id, cwd, normalized)
-    except Exception:
-        pass
+    except Exception as exc:
+        # Non-fatal, but log to stderr so a send_batch bug (TypeError from a
+        # refactor, AttributeError, etc.) is diagnosable rather than silently
+        # eaten. KeyboardInterrupt/SystemExit derive from BaseException and
+        # still propagate, so the session can always be interrupted.
+        print(f"claude_session_hook: telemetry send failed: {exc}", file=sys.stderr)
 
 
 def main():

--- a/tools/claude_session_hook.py
+++ b/tools/claude_session_hook.py
@@ -29,7 +29,6 @@ import socket
 import sys
 from datetime import datetime, timezone
 from pathlib import Path
-from urllib.error import HTTPError, URLError
 from urllib.request import Request, urlopen
 
 API_URL = os.environ.get("MEMORY_API_URL", "")
@@ -143,10 +142,11 @@ def upload_current_turn(session_id, cwd, transcript_path):
     current_turn = find_current_turn(events)
     normalized = [normalize_event(e) for e in current_turn]
 
-    # Send as batch
+    # Send as batch. This is fire-and-forget telemetry: a network timeout,
+    # connection error, or malformed response must never break the session.
     try:
         send_batch(session_id, cwd, normalized)
-    except (HTTPError, URLError):
+    except Exception:
         pass
 
 

--- a/tools/claude_snapshot.py
+++ b/tools/claude_snapshot.py
@@ -311,7 +311,9 @@ def upload_snapshot(host: str, api_key: str, name: str, data: bytes, hash_: str,
     headers = {"Authorization": f"Bearer {api_key}"}
 
     # Check if already exists
-    resp = requests.get(f"{host}/claude/snapshots/{hash_}", headers=headers)
+    resp = requests.get(
+        f"{host}/claude/snapshots/{hash_}", headers=headers, timeout=30
+    )
     if resp.status_code == 200:
         try:
             result = {"id": resp.json()["id"], "hash": hash_, "created": False}
@@ -330,6 +332,7 @@ def upload_snapshot(host: str, api_key: str, name: str, data: bytes, hash_: str,
         headers=headers,
         files={"file": ("snapshot.tar.gz", data, "application/gzip")},
         data={"name": name},
+        timeout=300,
     )
     if resp.status_code != 200:
         print(f"Error uploading: {resp.status_code}", file=sys.stderr)

--- a/tools/deploy.sh
+++ b/tools/deploy.sh
@@ -206,8 +206,18 @@ run_session() {
 
     if [[ -n "$snapshot" ]]; then
         # mktemp on the server guarantees a unique path even with concurrent
-        # sessions / multiple operators (local $$ would not). Cleaned up below.
-        temp_snapshot=$(ssh "$REMOTE_HOST" "mktemp /tmp/snapshot-XXXXXX.tar.gz")
+        # sessions / multiple operators (local $$ would not).
+        # Suppress stderr so a stray warning line cannot corrupt the captured path.
+        temp_snapshot=$(ssh "$REMOTE_HOST" "mktemp /tmp/snapshot-XXXXXX.tar.gz" 2>/dev/null)
+        if [[ -z "$temp_snapshot" ]]; then
+            echo -e "${RED}Error: failed to create temp snapshot path on $REMOTE_HOST${NC}"
+            return 1
+        fi
+        # Remove the server-side temp file on any script exit, including
+        # interrupts (Ctrl-C / SIGTERM), so it cannot leak. mktemp output is
+        # always a safe path (/tmp/snapshot-XXXXXX.tar.gz), so embedding it in
+        # the trap string is sound.
+        trap "ssh '$REMOTE_HOST' \"rm -f '$temp_snapshot'\" 2>/dev/null || true" EXIT
         ssh "$REMOTE_HOST" "cp '$snapshot' '$temp_snapshot'"
         docker_cmd="$docker_cmd -v $temp_snapshot:/snapshot/snapshot.tar.gz:ro"
     fi
@@ -231,16 +241,9 @@ run_session() {
     docker_cmd="$docker_cmd claude-cloud:latest"
 
     # Run the session. Capture the exit code via `|| ...` so that `set -e`
-    # does not abort before the cleanup below when the session exits non-zero.
+    # does not abort before returning; the EXIT trap handles temp cleanup.
     local session_status=0
     ssh "$REMOTE_HOST" "$docker_cmd" || session_status=$?
-
-    # Remove the server-side temp snapshot (the container mounted it read-only
-    # and has now exited, so it is safe to delete).
-    if [[ -n "$temp_snapshot" ]]; then
-        ssh "$REMOTE_HOST" "rm -f '$temp_snapshot'" \
-            || echo -e "${YELLOW}Warning: could not remove $temp_snapshot on $REMOTE_HOST${NC}"
-    fi
 
     return $session_status
 }

--- a/tools/deploy.sh
+++ b/tools/deploy.sh
@@ -143,6 +143,7 @@ run_session() {
     local github_token_write=""
     local custom_cmd=""
     local rebuild=true
+    local temp_snapshot=""
 
     # Parse options
     while [[ $# -gt 0 ]]; do
@@ -204,11 +205,11 @@ run_session() {
     fi
 
     if [[ -n "$snapshot" ]]; then
-        # Use unique temp file to avoid race condition with concurrent sessions
-        local temp_snapshot="/tmp/snapshot-$$.tar.gz"
+        # mktemp on the server guarantees a unique path even with concurrent
+        # sessions / multiple operators (local $$ would not). Cleaned up below.
+        temp_snapshot=$(ssh "$REMOTE_HOST" "mktemp /tmp/snapshot-XXXXXX.tar.gz")
         ssh "$REMOTE_HOST" "cp '$snapshot' '$temp_snapshot'"
         docker_cmd="$docker_cmd -v $temp_snapshot:/snapshot/snapshot.tar.gz:ro"
-        # Note: temp file cleanup is handled by the next run or system tmpfs cleanup
     fi
 
     if [[ -n "$environment" ]]; then
@@ -229,9 +230,19 @@ run_session() {
 
     docker_cmd="$docker_cmd claude-cloud:latest"
 
-    # Run the session
-    ssh "$REMOTE_HOST" "$docker_cmd"
-    return $?
+    # Run the session. Capture the exit code via `|| ...` so that `set -e`
+    # does not abort before the cleanup below when the session exits non-zero.
+    local session_status=0
+    ssh "$REMOTE_HOST" "$docker_cmd" || session_status=$?
+
+    # Remove the server-side temp snapshot (the container mounted it read-only
+    # and has now exited, so it is safe to delete).
+    if [[ -n "$temp_snapshot" ]]; then
+        ssh "$REMOTE_HOST" "rm -f '$temp_snapshot'" \
+            || echo -e "${YELLOW}Warning: could not remove $temp_snapshot on $REMOTE_HOST${NC}"
+    fi
+
+    return $session_status
 }
 
 # Main

--- a/tools/diagnose.sh
+++ b/tools/diagnose.sh
@@ -131,8 +131,12 @@ db_query() {
         exit 1
     fi
     # Enforce read-only at the Postgres level via PGOPTIONS: every transaction
-    # in this session is read-only, so any write (even one smuggled past a
+    # in this session is read-only, so plain DML/DDL (even one smuggled past a
     # naive "starts with SELECT" check via `;`) fails with a clear error.
+    # Caveat: default_transaction_read_only does NOT block SELECTs that invoke
+    # volatile functions with side effects (e.g. pg_terminate_backend, lo_export,
+    # SECURITY DEFINER functions that write). This is an acceptable residual for
+    # a diagnostics tool run by trusted operators, not a hard sandbox.
     echo -e "${GREEN}Running query (read-only session):${NC}"
     remote "cd $REMOTE_DIR && docker compose exec -T -e PGOPTIONS='-c default_transaction_read_only=on' postgres psql -U kb -d kb -c $(qt "$query")"
 }

--- a/tools/diagnose.sh
+++ b/tools/diagnose.sh
@@ -46,15 +46,22 @@ remote() {
     ssh "$REMOTE_HOST" "$@"
 }
 
+# Single-quote a value so it survives re-parsing by the remote shell
+# (handles spaces and embedded single quotes). Use for any user-supplied
+# value interpolated into a remote() command string.
+qt() {
+    printf "'%s'" "${1//\'/\'\\\'\'}"
+}
+
 docker_logs() {
     local service="${1:-}"
     local lines="${2:-100}"
     if [ -n "$service" ]; then
         echo -e "${GREEN}Logs for $service (last $lines lines):${NC}"
-        remote "cd $REMOTE_DIR && docker compose logs --tail=$lines $service"
+        remote "cd $REMOTE_DIR && docker compose logs --tail=$(qt "$lines") $(qt "$service")"
     else
         echo -e "${GREEN}All logs (last $lines lines):${NC}"
-        remote "cd $REMOTE_DIR && docker compose logs --tail=$lines"
+        remote "cd $REMOTE_DIR && docker compose logs --tail=$(qt "$lines")"
     fi
 }
 
@@ -82,7 +89,7 @@ list_dir() {
     local path="${1:-.}"
     # Ensure path is within project directory for safety
     echo -e "${GREEN}Contents of $path:${NC}"
-    remote "cd $REMOTE_DIR && ls -la $path"
+    remote "cd $REMOTE_DIR && ls -la $(qt "$path")"
 }
 
 cat_file() {
@@ -92,7 +99,7 @@ cat_file() {
         exit 1
     fi
     echo -e "${GREEN}Contents of $file:${NC}"
-    remote "cd $REMOTE_DIR && cat $file"
+    remote "cd $REMOTE_DIR && cat $(qt "$file")"
 }
 
 tail_file() {
@@ -103,7 +110,7 @@ tail_file() {
         exit 1
     fi
     echo -e "${GREEN}Last $lines lines of $file:${NC}"
-    remote "cd $REMOTE_DIR && tail -n $lines $file"
+    remote "cd $REMOTE_DIR && tail -n $(qt "$lines") $(qt "$file")"
 }
 
 grep_files() {
@@ -114,7 +121,7 @@ grep_files() {
         exit 1
     fi
     echo -e "${GREEN}Searching for '$pattern' in $path:${NC}"
-    remote "cd $REMOTE_DIR && grep -r --color=always '$pattern' $path || true"
+    remote "cd $REMOTE_DIR && grep -r --color=always -- $(qt "$pattern") $(qt "$path") || true"
 }
 
 db_query() {
@@ -123,13 +130,11 @@ db_query() {
         echo -e "${RED}Error: No query specified${NC}"
         exit 1
     fi
-    # Only allow SELECT queries for safety
-    if ! echo "$query" | grep -qi "^select"; then
-        echo -e "${RED}Error: Only SELECT queries are allowed${NC}"
-        exit 1
-    fi
-    echo -e "${GREEN}Running query:${NC}"
-    remote "cd $REMOTE_DIR && docker compose exec -T postgres psql -U kb -d kb -c \"$query\""
+    # Enforce read-only at the Postgres level via PGOPTIONS: every transaction
+    # in this session is read-only, so any write (even one smuggled past a
+    # naive "starts with SELECT" check via `;`) fails with a clear error.
+    echo -e "${GREEN}Running query (read-only session):${NC}"
+    remote "cd $REMOTE_DIR && docker compose exec -T -e PGOPTIONS='-c default_transaction_read_only=on' postgres psql -U kb -d kb -c $(qt "$query")"
 }
 
 http_get() {
@@ -144,7 +149,7 @@ http_get() {
         path="/$path"
     fi
     echo -e "${GREEN}GET http://localhost:${port}${path}${NC}"
-    remote "curl -s -w '\n\nHTTP Status: %{http_code}\n' 'http://localhost:${port}${path}'"
+    remote "curl -s -w '\n\nHTTP Status: %{http_code}\n' $(qt "http://localhost:${port}${path}")"
 }
 
 system_status() {

--- a/tools/install.sh
+++ b/tools/install.sh
@@ -173,10 +173,10 @@ info "The following API keys are needed for core functionality."
 info "You can get them from the respective provider dashboards."
 echo ""
 
-# OpenAI - for embeddings fallback and some LLM features
+# OpenAI - misc LLM-backed features
 prompt_if_missing "OPENAI_API_KEY" \
     "OpenAI API Key (https://platform.openai.com/api-keys)
-    Used for: embeddings fallback, some LLM features" \
+    Used for: misc LLM-backed features (notes, observation extraction)" \
     "true"
 
 # Also write to secrets file for Docker
@@ -197,10 +197,10 @@ if [ -n "$anthropic_key" ]; then
     write_secret "anthropic_key.txt" "$anthropic_key"
 fi
 
-# Voyage AI - primary embedding provider
+# Voyage AI - embeddings + reranking
 prompt_if_missing "VOYAGE_API_KEY" \
     "Voyage AI API Key (https://dash.voyageai.com/api-keys)
-    Used for: primary embeddings (recommended for best search quality)" \
+    Used for: all embeddings (voyage-3-large / voyage-multimodal-3) and reranking" \
     "true"
 
 # ─────────────────────────────────────────────────────────────────────
@@ -350,6 +350,7 @@ echo ""
 info "Next steps:"
 echo "  1. Review configuration: $ENV_FILE"
 echo "  2. Start services: docker compose up -d"
-echo "  3. Create a user: python tools/add_user.py --email you@example.com --password yourpass --name 'Your Name'"
+echo "  3. Create a user: docker compose exec api python tools/add_user.py \\"
+echo "       --email you@example.com --password yourpass --name 'Your Name'"
 echo "  4. Access the app: http://localhost:8000"
 echo ""

--- a/tools/restore_files.py
+++ b/tools/restore_files.py
@@ -37,20 +37,21 @@ def list_backups(bucket: str, prefix: str, region: str) -> list[str]:
     """List available encrypted file backups in S3."""
     s3 = boto3.client("s3", region_name=region)
 
+    backups = []
     try:
-        response = s3.list_objects_v2(Bucket=bucket, Prefix=prefix)
+        paginator = s3.get_paginator("list_objects_v2")
+        for page in paginator.paginate(Bucket=bucket, Prefix=prefix):
+            for obj in page.get("Contents", []):
+                key = obj["Key"]
+                if not key.endswith(".tar.gz.enc"):
+                    continue
+                name = key.split("/")[-1]
+                size_mb = obj["Size"] / (1024 * 1024)
+                modified = obj["LastModified"].strftime("%Y-%m-%d %H:%M:%S")
+                backups.append(f"{name:40} {size_mb:8.2f} MB  {modified}")
     except Exception as e:
         print(f"Error listing S3 bucket: {e}", file=sys.stderr)
         return []
-
-    backups = []
-    for obj in response.get("Contents", []):
-        key = obj["Key"]
-        if key.endswith(".tar.gz.enc"):
-            name = key.split("/")[-1]
-            size_mb = obj["Size"] / (1024 * 1024)
-            modified = obj["LastModified"].strftime("%Y-%m-%d %H:%M:%S")
-            backups.append(f"{name:40} {size_mb:8.2f} MB  {modified}")
 
     return backups
 
@@ -90,7 +91,7 @@ def decrypt_and_extract(encrypted_data: bytes, password: str, output_dir: Path) 
         output_dir.mkdir(parents=True, exist_ok=True)
         tar_buffer = io.BytesIO(decrypted)
         with tarfile.open(fileobj=tar_buffer, mode="r:gz") as tar:
-            tar.extractall(output_dir)
+            tar.extractall(output_dir, filter="data")
         print("Extraction complete")
         return True
     except Exception as e:

--- a/tools/run_celery_task.py
+++ b/tools/run_celery_task.py
@@ -115,7 +115,6 @@ TASK_MAPPINGS = {
 QUEUE_MAPPINGS = {
     "email": "email",
     "ebook": "ebooks",
-    "photo": "photo_embed",
 }
 
 
@@ -380,10 +379,17 @@ def maintenance_reingest_all_empty_source_items(ctx):
 
 @maintenance.command("reingest-chunk")
 @click.option("--chunk-id", required=True, help="Chunk ID to reingest")
+@click.option(
+    "--collection",
+    required=True,
+    help="Qdrant collection the chunk belongs to (e.g. mail, blog, book)",
+)
 @click.pass_context
-def maintenance_reingest_chunk(ctx, chunk_id):
+def maintenance_reingest_chunk(ctx, chunk_id, collection):
     """Reingest a specific chunk."""
-    execute_task(ctx, "maintenance", "reingest_chunk", chunk_id=chunk_id)
+    execute_task(
+        ctx, "maintenance", "reingest_chunk", chunk_id=chunk_id, collection=collection
+    )
 
 
 @cli.group()  # type: ignore[attr-defined]
@@ -446,7 +452,7 @@ def blogs_add_article_feed(ctx, url, title, description, tags, active, check_int
         url=url,
         title=title,
         description=description,
-        tags=tags.split(","),
+        tags=[t.strip() for t in tags.split(",") if t.strip()],
         active=active,
         check_interval=check_interval,
     )

--- a/tools/run_celery_task.py
+++ b/tools/run_celery_task.py
@@ -2,9 +2,9 @@
 """
 Script to run Celery tasks on the Docker Compose setup from your local machine.
 
-This script connects to the RabbitMQ broker running in Docker and sends tasks
-to the workers. It requires the same dependencies as the workers to import
-the task definitions.
+This script connects to the Celery broker (Redis) running in Docker and sends
+tasks to the workers. It requires the same dependencies as the workers to
+import the task definitions.
 
 Usage:
     python run_celery_task.py --help
@@ -162,7 +162,8 @@ def cli(ctx, wait, timeout):
     except Exception as e:
         click.echo(f"Error connecting to Celery broker: {e}")
         click.echo(
-            "Make sure Docker Compose is running and RabbitMQ is accessible on localhost:15673"
+            "Make sure Docker Compose is running and the Redis broker is reachable "
+            "(REDIS_HOST/REDIS_PORT in .env)"
         )
         sys.exit(1)
 


### PR DESCRIPTION
## Summary

Audited the project documentation and all helper scripts for drift against the current codebase, then fixed everything found. Three commits:

### 1. `docs: sync README and docs with current codebase state`
- Voyage (not OpenAI) does all embeddings + reranking — corrected in README, CLAUDE.md, and install.sh.
- README quick-start now creates users via `docker compose exec` (the host CLI can't reach Postgres — no published port by default).
- Documented that `docker-compose.override.yml` is gitignored and must be created for host-side dev; removed false "checked into the repo" claims.
- Rewrote `SEARCH_INVESTIGATION.md` to match the current pipeline (`voyage-3-large` 1024d, RRF fusion).
- Corrected the CLAUDE.md content-types table (parser/task/queue names) and project-structure paths (projects/teams are MCP subservers).

### 2. `fix: correctness bugs across helper scripts`
- `run_celery_task.py`: `reingest-chunk` never passed the required `collection` arg → task always `TypeError`'d on the worker; added `--collection`.
- `dev.sh`: use `docker compose` (v2) instead of EOL `docker-compose`; `mkdir -p secrets` before writing into it.
- `diagnose.sh`: quote user-supplied args so paths with spaces work through the remote shell; enforce read-only via `PGOPTIONS` instead of a bypassable "starts with SELECT" check.
- `deploy.sh`: server-side temp snapshot used the local PID (collision risk) and leaked → use remote `mktemp` + cleanup.
- `backup_databases.sh`: an S3 list failure silently skipped backup pruning → now logged.
- `restore_files.py`: paginate `list_objects_v2` (was truncating at 1000); extract tarballs with `filter="data"` to block path traversal.
- `claude_session_hook.py` / `claude_snapshot.py`: widen except so a socket timeout can't crash the hook; add HTTP timeouts.

### 3. `fix: address review-loop feedback on helper scripts`
- `dev.sh`: write `REDIS_PORT=16379` so host-side dev matches the README override example.
- `deploy.sh`: register an `EXIT` trap so the temp snapshot is cleaned up even on Ctrl-C/SIGTERM.
- `diagnose.sh`: document that `default_transaction_read_only` is not a hard sandbox (volatile side-effecting functions still run).
- `claude_session_hook.py`: log telemetry-send failures to stderr instead of silently swallowing them.

## Test plan

- [ ] `bash -n` passes on all modified shell scripts; `py_compile` passes on modified Python scripts (verified locally).
- [ ] Documentation claims spot-checked against `docker-compose.yaml`, `settings.py`, `collections.py`, and the source tree.
- [ ] 3 rounds of internal review (differ-review) — final verdict: approve.
- [ ] Reviewer: confirm the `dev.sh`-generated `.env` ports agree with the README override example.

🤖 Generated with [Claude Code](https://claude.com/claude-code)