### PR TITLE
Verify GitHub account identity instead of trusting self-attested name (#84)

### DIFF
--- a/db/migrations/versions/20260516_github_account_verified_login.py
+++ b/db/migrations/versions/20260516_github_account_verified_login.py
@@ -1,0 +1,35 @@
+"""Add verified_login column to github_accounts.
+
+``GithubAccount.name`` is a self-attested display name supplied in the
+request body. ``meta_get_user`` exposed it to downstream MCP consumers,
+which let an attacker register their own valid PAT under someone else's
+claimed identity. ``verified_login`` holds the login GitHub itself
+reports for the stored credentials, so consumers have a field they can
+trust for identity decisions. It is NULL until verification succeeds.
+
+Revision ID: 20260516_github_account_verified_login
+Revises: 20260516_source_updated_at_index
+Create Date: 2026-05-16
+"""
+
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+revision: str = "20260516_github_account_verified_login"
+down_revision: Union[str, None] = "20260516_source_updated_at_index"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "github_accounts",
+        sa.Column("verified_login", sa.Text(), nullable=True),
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("github_accounts", "verified_login")

--- a/db/migrations/versions/20260516_github_account_verified_login.py
+++ b/db/migrations/versions/20260516_github_account_verified_login.py
@@ -7,7 +7,7 @@ claimed identity. ``verified_login`` holds the login GitHub itself
 reports for the stored credentials, so consumers have a field they can
 trust for identity decisions. It is NULL until verification succeeds.
 
-Revision ID: 20260516_github_account_verified_login
+Revision ID: 20260516_gh_verified_login
 Revises: 20260516_source_updated_at_index
 Create Date: 2026-05-16
 """
@@ -18,7 +18,7 @@ from alembic import op
 import sqlalchemy as sa
 
 
-revision: str = "20260516_github_account_verified_login"
+revision: str = "20260516_gh_verified_login"
 down_revision: Union[str, None] = "20260516_source_updated_at_index"
 branch_labels: Union[str, Sequence[str], None] = None
 depends_on: Union[str, Sequence[str], None] = None

--- a/frontend/src/components/sources/panels/GitHubPanel.tsx
+++ b/frontend/src/components/sources/panels/GitHubPanel.tsx
@@ -129,6 +129,9 @@ export const GitHubPanel = () => {
                   <h4 className={styles.cardTitle}>{account.name}</h4>
                   <p className={styles.cardSubtitle}>
                     {account.auth_type === 'pat' ? 'Personal Access Token' : 'GitHub App'}
+                    {account.verified_login
+                      ? ` · verified as ${account.verified_login}`
+                      : ' · unverified'}
                     {!account.active && ' (disabled)'}
                   </p>
                 </div>

--- a/frontend/src/hooks/useSources.ts
+++ b/frontend/src/hooks/useSources.ts
@@ -136,6 +136,8 @@ export interface GithubRepo {
 export interface GithubAccount {
   id: number
   name: string
+  /** GitHub-verified login for the stored credentials; null if unverified. */
+  verified_login: string | null
   auth_type: 'pat' | 'app'
   has_access_token: boolean
   has_private_key: boolean

--- a/src/memory/api/MCP/servers/meta.py
+++ b/src/memory/api/MCP/servers/meta.py
@@ -130,8 +130,16 @@ def _get_current_user(session: DBSession) -> dict:
         .filter(GithubAccount.user_id == user_session.user.id)
         .all()
     )
+    # ``name`` is self-attested and must not be used for identity
+    # decisions; ``verified_login`` is what GitHub reports for the
+    # stored credentials and is None until verified (see issue #84).
     user_info["github_accounts"] = [
-        {"name": a.name, "auth_type": a.auth_type} for a in github_accounts
+        {
+            "name": a.name,
+            "auth_type": a.auth_type,
+            "verified_login": a.verified_login,
+        }
+        for a in github_accounts
     ]
 
     # Enrich from linked Person record (via User.person or discord_accounts)

--- a/src/memory/api/github_sources.py
+++ b/src/memory/api/github_sources.py
@@ -296,7 +296,13 @@ def create_account(
         private_key=data.private_key,
     )
     db.add(account)
-    db.flush()  # populate account.id for verification logging
+    # Commit the row first, *then* verify. Identity verification makes a
+    # GitHub network call (up to ~90s worst case for App auth); keeping it
+    # outside the transaction means the DB connection and INSERT are not
+    # held open for its duration. The account row itself is intentionally
+    # decoupled from GitHub uptime (see issue #84 design notes).
+    db.commit()
+    db.refresh(account)
     # Resolve identity from the credentials themselves — never trust the
     # client-supplied ``name`` as a GitHub identity (see issue #84).
     account.verified_login = verify_account_identity(account)
@@ -348,11 +354,16 @@ def update_account(
         account.private_key = updates.private_key
         credentials_changed = True
 
-    if credentials_changed:
-        account.verified_login = verify_account_identity(account)
-
+    # Commit the field changes first so the transaction (and the row
+    # UPDATE lock) is not held open across the GitHub network call that
+    # identity verification performs. See create_account for rationale.
     db.commit()
     db.refresh(account)
+
+    if credentials_changed:
+        account.verified_login = verify_account_identity(account)
+        db.commit()
+        db.refresh(account)
 
     return account_to_response(account)
 

--- a/src/memory/api/github_sources.py
+++ b/src/memory/api/github_sources.py
@@ -86,7 +86,8 @@ class GithubRepoResponse(BaseModel):
 
 class GithubAccountResponse(BaseModel):
     id: int
-    name: str
+    name: str  # Self-attested display name — not an identity claim.
+    verified_login: str | None  # GitHub-verified login; None if unverified.
     auth_type: str
     has_access_token: bool
     has_private_key: bool
@@ -164,6 +165,7 @@ def account_to_response(account: GithubAccount) -> GithubAccountResponse:
     return GithubAccountResponse(
         id=cast(int, account.id),
         name=cast(str, account.name),
+        verified_login=cast(str | None, account.verified_login),
         auth_type=cast(str, account.auth_type),
         has_access_token=bool(account.access_token),
         has_private_key=bool(account.private_key),
@@ -175,6 +177,36 @@ def account_to_response(account: GithubAccount) -> GithubAccountResponse:
         updated_at=account.updated_at.isoformat() if account.updated_at else "",
         repos=[repo_to_response(repo) for repo in account.repos],
     )
+
+
+def account_credentials(account: GithubAccount) -> GithubCredentials:
+    """Build a GithubCredentials object from a stored account."""
+    return GithubCredentials(
+        auth_type=cast(str, account.auth_type),
+        access_token=cast(str | None, account.access_token),
+        app_id=cast(int | None, account.app_id),
+        installation_id=cast(int | None, account.installation_id),
+        private_key=cast(str | None, account.private_key),
+    )
+
+
+def verify_account_identity(account: GithubAccount) -> str | None:
+    """Resolve the real GitHub login for an account's stored credentials.
+
+    Returns the login GitHub itself reports, or None if the credentials
+    can't be verified (invalid, or GitHub unreachable). The result is
+    never derived from user input, so it is safe to store as a verified
+    identity. Verification failures are non-fatal: the account is still
+    usable, it just stays unverified until ``validate_account`` succeeds.
+    """
+    try:
+        client = GithubClient(account_credentials(account))
+        return client.get_authenticated_login()
+    except Exception as e:
+        logger.warning(
+            "GitHub identity verification failed for account %s: %s", account.id, e
+        )
+        return None
 
 
 # --- Account Endpoints ---
@@ -264,6 +296,10 @@ def create_account(
         private_key=data.private_key,
     )
     db.add(account)
+    db.flush()  # populate account.id for verification logging
+    # Resolve identity from the credentials themselves — never trust the
+    # client-supplied ``name`` as a GitHub identity (see issue #84).
+    account.verified_login = verify_account_identity(account)
     db.commit()
     db.refresh(account)
 
@@ -293,16 +329,27 @@ def update_account(
 
     if updates.name is not None:
         account.name = updates.name
-    if updates.access_token is not None:
-        account.access_token = updates.access_token
-    if updates.app_id is not None:
-        account.app_id = updates.app_id
-    if updates.installation_id is not None:
-        account.installation_id = updates.installation_id
-    if updates.private_key is not None:
-        account.private_key = updates.private_key
     if updates.active is not None:
         account.active = updates.active
+
+    # Track credential changes: if any change, the previously verified
+    # login no longer reflects the stored credentials and must be redone.
+    credentials_changed = False
+    if updates.access_token is not None:
+        account.access_token = updates.access_token
+        credentials_changed = True
+    if updates.app_id is not None:
+        account.app_id = updates.app_id
+        credentials_changed = True
+    if updates.installation_id is not None:
+        account.installation_id = updates.installation_id
+        credentials_changed = True
+    if updates.private_key is not None:
+        account.private_key = updates.private_key
+        credentials_changed = True
+
+    if credentials_changed:
+        account.verified_login = verify_account_identity(account)
 
     db.commit()
     db.refresh(account)
@@ -331,30 +378,28 @@ def validate_account(
     user: User = Depends(get_current_user),
     db: Session = Depends(get_session),
 ):
-    """Validate GitHub API access for an account."""
+    """Validate GitHub API access for an account.
+
+    On success this also (re)stores the GitHub-verified login, so it
+    doubles as the re-verification path for accounts whose verification
+    was skipped because GitHub was unreachable at create/update time.
+    """
     account = get_user_account(db, GithubAccount, account_id, user)
 
     try:
-        credentials = GithubCredentials(
-            auth_type=cast(str, account.auth_type),
-            access_token=cast(str | None, account.access_token),
-            app_id=cast(int | None, account.app_id),
-            installation_id=cast(int | None, account.installation_id),
-            private_key=cast(str | None, account.private_key),
-        )
-        client = GithubClient(credentials)
-
-        # Test by getting authenticated user info
-        user_info = client.get_authenticated_user()
-
-        return {
-            "status": "success",
-            "message": f"Authenticated as {user_info.get('login', 'unknown')}",
-            "user": user_info.get("login"),
-            "scopes": user_info.get("scopes", []),
-        }
+        client = GithubClient(account_credentials(account))
+        login = client.get_authenticated_login()
     except Exception as e:
         return {"status": "error", "message": str(e)}
+
+    account.verified_login = login
+    db.commit()
+
+    return {
+        "status": "success",
+        "message": f"Authenticated as {login}",
+        "user": login,
+    }
 
 
 class AvailableRepoResponse(BaseModel):
@@ -438,14 +483,7 @@ def list_available_repos(
             return [AvailableRepoResponse(**repo) for repo in cached]
 
     try:
-        credentials = GithubCredentials(
-            auth_type=cast(str, account.auth_type),
-            access_token=cast(str | None, account.access_token),
-            app_id=cast(int | None, account.app_id),
-            installation_id=cast(int | None, account.installation_id),
-            private_key=cast(str | None, account.private_key),
-        )
-        client = GithubClient(credentials)
+        client = GithubClient(account_credentials(account))
 
         repos_data = []
         for repo in client.list_repos(max_repos=max_repos, include_archived=include_archived):
@@ -480,14 +518,7 @@ def list_available_projects(
     account = get_user_account(db, GithubAccount, account_id, user)
 
     try:
-        credentials = GithubCredentials(
-            auth_type=cast(str, account.auth_type),
-            access_token=cast(str | None, account.access_token),
-            app_id=cast(int | None, account.app_id),
-            installation_id=cast(int | None, account.installation_id),
-            private_key=cast(str | None, account.private_key),
-        )
-        client = GithubClient(credentials)
+        client = GithubClient(account_credentials(account))
 
         projects = []
         for project in client.list_projects(owner, is_org, include_closed):
@@ -534,14 +565,7 @@ def add_repo(
 
     # Fetch repo from GitHub to validate and get canonical info
     try:
-        credentials = GithubCredentials(
-            auth_type=cast(str, account.auth_type),
-            access_token=cast(str | None, account.access_token),
-            app_id=cast(int | None, account.app_id),
-            installation_id=cast(int | None, account.installation_id),
-            private_key=cast(str | None, account.private_key),
-        )
-        client = GithubClient(credentials)
+        client = GithubClient(account_credentials(account))
         github_repo = client.get_repo(data.owner, data.name)
         if not github_repo:
             raise HTTPException(
@@ -794,14 +818,7 @@ def add_project(
 
     # Fetch project from GitHub
     try:
-        credentials = GithubCredentials(
-            auth_type=cast(str, account.auth_type),
-            access_token=cast(str | None, account.access_token),
-            app_id=cast(int | None, account.app_id),
-            installation_id=cast(int | None, account.installation_id),
-            private_key=cast(str | None, account.private_key),
-        )
-        client = GithubClient(credentials)
+        client = GithubClient(account_credentials(account))
 
         # Fetch the specific project directly via GraphQL
         project_data = client.fetch_project(data.owner, data.project_number, data.is_org)

--- a/src/memory/common/db/models/sources.py
+++ b/src/memory/common/db/models/sources.py
@@ -302,7 +302,12 @@ class GithubAccount(Base):
     user_id: Mapped[int] = mapped_column(
         Integer, ForeignKey("users.id", ondelete="CASCADE"), nullable=False
     )
-    name: Mapped[str] = mapped_column(Text, nullable=False)  # Display name
+    name: Mapped[str] = mapped_column(Text, nullable=False)  # Self-attested display name
+
+    # Login GitHub itself reports for the stored credentials. Unlike
+    # ``name`` this is never taken from user input, so it is the only
+    # field safe to use for identity decisions. NULL until verified.
+    verified_login: Mapped[str | None] = mapped_column(Text, nullable=True)
 
     # Authentication - support both PAT and GitHub App
     auth_type: Mapped[str] = mapped_column(Text, nullable=False)  # 'pat' or 'app'

--- a/src/memory/common/github/core.py
+++ b/src/memory/common/github/core.py
@@ -138,8 +138,8 @@ class GithubClientCore:
         self.session.headers["X-GitHub-Api-Version"] = "2022-11-28"
         self.session.headers["User-Agent"] = "memory-kb-github-sync"
 
-    def _get_installation_token(self) -> str:
-        """Get installation access token for GitHub App."""
+    def _generate_app_jwt(self) -> str:
+        """Generate a short-lived app-level JWT for GitHub App auth."""
         try:
             import jwt
         except ImportError:
@@ -147,8 +147,6 @@ class GithubClientCore:
 
         if not self.credentials.app_id or not self.credentials.private_key:
             raise ValueError("app_id and private_key required for app auth")
-        if not self.credentials.installation_id:
-            raise ValueError("installation_id required for app auth")
 
         now = int(time.time())
         payload = {
@@ -156,9 +154,14 @@ class GithubClientCore:
             "exp": now + 600,
             "iss": self.credentials.app_id,
         }
-        jwt_token = jwt.encode(
-            payload, self.credentials.private_key, algorithm="RS256"
-        )
+        return jwt.encode(payload, self.credentials.private_key, algorithm="RS256")
+
+    def _get_installation_token(self) -> str:
+        """Get installation access token for GitHub App."""
+        if not self.credentials.installation_id:
+            raise ValueError("installation_id required for app auth")
+
+        jwt_token = self._generate_app_jwt()
 
         # Retry with exponential backoff for transient errors
         max_retries = 3
@@ -205,3 +208,47 @@ class GithubClientCore:
         response = self.session.get(f"{GITHUB_API_URL}/user", timeout=30)
         response.raise_for_status()
         return response.json()
+
+    def get_app_installation(self) -> dict[str, Any]:
+        """Fetch installation metadata for App auth using an app-level JWT.
+
+        The installation token used for normal API calls cannot read
+        ``/app/installations/...``; that endpoint needs the app JWT.
+        """
+        if self.credentials.auth_type != "app":
+            raise ValueError("get_app_installation requires app auth")
+        if not self.credentials.installation_id:
+            raise ValueError("installation_id required for app auth")
+
+        jwt_token = self._generate_app_jwt()
+        response = requests.get(
+            f"{GITHUB_API_URL}/app/installations/{self.credentials.installation_id}",
+            headers={
+                "Authorization": f"Bearer {jwt_token}",
+                "Accept": "application/vnd.github+json",
+            },
+            timeout=30,
+        )
+        response.raise_for_status()
+        return response.json()
+
+    def get_authenticated_login(self) -> str:
+        """Return the GitHub login that owns the configured credentials.
+
+        For PAT auth this is the token owner (``GET /user``). For App
+        auth there is no user, so it is the account the installation
+        belongs to (``GET /app/installations/{id}``). The value comes
+        straight from GitHub, so callers may treat it as a verified
+        identity rather than self-attested input.
+        """
+        if self.credentials.auth_type == "app":
+            account = self.get_app_installation().get("account") or {}
+            login = account.get("login")
+            if not login:
+                raise ValueError("GitHub installation response missing account login")
+            return login
+
+        login = self.get_authenticated_user().get("login")
+        if not login:
+            raise ValueError("GitHub /user response missing login")
+        return login

--- a/tests/memory/api/test_github_sources.py
+++ b/tests/memory/api/test_github_sources.py
@@ -316,7 +316,10 @@ def test_update_account_reverifies_on_credential_change(
     assert account.verified_login == "new-identity"
 
 
-def test_update_account_name_only_keeps_verified_login(client, db_session, user):
+@patch("memory.api.github_sources.GithubClient")
+def test_update_account_name_only_keeps_verified_login(
+    mock_client_class, client, db_session, user
+):
     """Updating only the display name must not touch the verified identity."""
     account = GithubAccount(
         user_id=user.id,
@@ -334,6 +337,8 @@ def test_update_account_name_only_keeps_verified_login(client, db_session, user)
     )
 
     assert response.status_code == 200
+    # A name-only update must not re-verify: no GitHub client constructed.
+    mock_client_class.assert_not_called()
     db_session.refresh(account)
     assert account.name == "Renamed"
     assert account.verified_login == "octocat"

--- a/tests/memory/api/test_github_sources.py
+++ b/tests/memory/api/test_github_sources.py
@@ -57,8 +57,24 @@ def test_list_accounts_empty_when_no_accounts(client, db_session, user):
 # ====== POST /github/accounts tests ======
 
 
-def test_create_account_pat_success(client, db_session, user):
+def make_github_client_mock(login: str | None = "octocat") -> Mock:
+    """Build a GithubClient mock whose credentials resolve to ``login``.
+
+    ``login=None`` simulates a verification failure (bad credentials or
+    GitHub unreachable) by raising from ``get_authenticated_login``.
+    """
+    mock_client = Mock()
+    if login is None:
+        mock_client.get_authenticated_login.side_effect = RuntimeError("bad creds")
+    else:
+        mock_client.get_authenticated_login.return_value = login
+    return mock_client
+
+
+@patch("memory.api.github_sources.GithubClient")
+def test_create_account_pat_success(mock_client_class, client, db_session, user):
     """Create GitHub account with PAT authentication succeeds."""
+    mock_client_class.return_value = make_github_client_mock("octocat")
     payload = {
         "name": "My GitHub PAT",
         "auth_type": "pat",
@@ -72,15 +88,20 @@ def test_create_account_pat_success(client, db_session, user):
     assert data["name"] == "My GitHub PAT"
     assert data["auth_type"] == "pat"
     assert data["has_access_token"] is True
+    # Identity is resolved from the credentials, not the request body.
+    assert data["verified_login"] == "octocat"
 
     # Verify account was created in database
     account = db_session.query(GithubAccount).filter_by(name="My GitHub PAT").first()
     assert account is not None
     assert account.user_id == user.id
+    assert account.verified_login == "octocat"
 
 
-def test_create_account_app_success(client, db_session, user):
+@patch("memory.api.github_sources.GithubClient")
+def test_create_account_app_success(mock_client_class, client, db_session, user):
     """Create GitHub account with App authentication succeeds."""
+    mock_client_class.return_value = make_github_client_mock("acme-org")
     payload = {
         "name": "My GitHub App",
         "auth_type": "app",
@@ -98,6 +119,45 @@ def test_create_account_app_success(client, db_session, user):
     assert data["app_id"] == 12345
     assert data["installation_id"] == 67890
     assert data["has_private_key"] is True
+    assert data["verified_login"] == "acme-org"
+
+
+@patch("memory.api.github_sources.GithubClient")
+def test_create_account_ignores_spoofed_name(mock_client_class, client, db_session, user):
+    """A client-supplied name cannot masquerade as a GitHub identity (issue #84)."""
+    mock_client_class.return_value = make_github_client_mock("real-attacker")
+    payload = {
+        "name": "trusted-maintainer",  # the spoofed identity
+        "auth_type": "pat",
+        "access_token": "ghp_attackers_own_token",
+    }
+
+    response = client.post("/github/accounts", json=payload)
+
+    assert response.status_code == 200
+    data = response.json()
+    # name is preserved as a display label, but verified_login reflects
+    # who GitHub says the token actually belongs to.
+    assert data["name"] == "trusted-maintainer"
+    assert data["verified_login"] == "real-attacker"
+
+
+@patch("memory.api.github_sources.GithubClient")
+def test_create_account_unverified_when_github_unreachable(
+    mock_client_class, client, db_session, user
+):
+    """Verification failures leave verified_login NULL rather than trusting input."""
+    mock_client_class.return_value = make_github_client_mock(None)
+    payload = {
+        "name": "My GitHub PAT",
+        "auth_type": "pat",
+        "access_token": "ghp_test123",
+    }
+
+    response = client.post("/github/accounts", json=payload)
+
+    assert response.status_code == 200
+    assert response.json()["verified_login"] is None
 
 
 @pytest.mark.parametrize(
@@ -205,8 +265,10 @@ def test_update_account_name(client, db_session, user):
         ("private_key", "-----BEGIN RSA PRIVATE KEY-----\nkey\n-----END RSA PRIVATE KEY-----"),
     ],
 )
-def test_update_account_fields(client, db_session, user, field, value):
+@patch("memory.api.github_sources.GithubClient")
+def test_update_account_fields(mock_client_class, client, db_session, user, field, value):
     """Update account fields succeeds."""
+    mock_client_class.return_value = make_github_client_mock("octocat")
     account = GithubAccount(
         user_id=user.id,
         name="Test Account",
@@ -226,6 +288,55 @@ def test_update_account_fields(client, db_session, user, field, value):
     # Verify in database
     db_session.refresh(account)
     assert getattr(account, field) == value
+
+
+@patch("memory.api.github_sources.GithubClient")
+def test_update_account_reverifies_on_credential_change(
+    mock_client_class, client, db_session, user
+):
+    """Changing credentials re-resolves the verified login from GitHub."""
+    mock_client_class.return_value = make_github_client_mock("new-identity")
+    account = GithubAccount(
+        user_id=user.id,
+        name="Test Account",
+        auth_type="pat",
+        access_token="old_token",
+        verified_login="old-identity",
+    )
+    db_session.add(account)
+    db_session.commit()
+
+    response = client.patch(
+        f"/github/accounts/{account.id}",
+        json={"access_token": "new_token"},
+    )
+
+    assert response.status_code == 200
+    db_session.refresh(account)
+    assert account.verified_login == "new-identity"
+
+
+def test_update_account_name_only_keeps_verified_login(client, db_session, user):
+    """Updating only the display name must not touch the verified identity."""
+    account = GithubAccount(
+        user_id=user.id,
+        name="Original Name",
+        auth_type="pat",
+        access_token="token123",
+        verified_login="octocat",
+    )
+    db_session.add(account)
+    db_session.commit()
+
+    response = client.patch(
+        f"/github/accounts/{account.id}",
+        json={"name": "Renamed"},
+    )
+
+    assert response.status_code == 200
+    db_session.refresh(account)
+    assert account.name == "Renamed"
+    assert account.verified_login == "octocat"
 
 
 def test_update_account_not_owned(regular_client, db_session, user, other_user):
@@ -292,6 +403,59 @@ def test_delete_account_not_owned(regular_client, db_session, user, other_user):
     response = regular_client.delete(f"/github/accounts/{account.id}")
 
     assert response.status_code == 404
+
+
+# ====== POST /github/accounts/{account_id}/validate tests ======
+
+
+@patch("memory.api.github_sources.GithubClient")
+def test_validate_account_persists_verified_login(
+    mock_client_class, client, db_session, user
+):
+    """A successful validation (re)stores the GitHub-verified login."""
+    mock_client_class.return_value = make_github_client_mock("octocat")
+    account = GithubAccount(
+        user_id=user.id,
+        name="Test Account",
+        auth_type="pat",
+        access_token="token123",
+    )
+    db_session.add(account)
+    db_session.commit()
+    assert account.verified_login is None
+
+    response = client.post(f"/github/accounts/{account.id}/validate")
+
+    assert response.status_code == 200
+    data = response.json()
+    assert data["status"] == "success"
+    assert data["user"] == "octocat"
+    db_session.refresh(account)
+    assert account.verified_login == "octocat"
+
+
+@patch("memory.api.github_sources.GithubClient")
+def test_validate_account_error_leaves_verified_login(
+    mock_client_class, client, db_session, user
+):
+    """A failed validation reports an error and does not overwrite identity."""
+    mock_client_class.return_value = make_github_client_mock(None)
+    account = GithubAccount(
+        user_id=user.id,
+        name="Test Account",
+        auth_type="pat",
+        access_token="token123",
+        verified_login="octocat",
+    )
+    db_session.add(account)
+    db_session.commit()
+
+    response = client.post(f"/github/accounts/{account.id}/validate")
+
+    assert response.status_code == 200
+    assert response.json()["status"] == "error"
+    db_session.refresh(account)
+    assert account.verified_login == "octocat"
 
 
 # ====== POST /github/accounts/{account_id}/repos tests ======


### PR DESCRIPTION
## Problem

Fixes #84. `POST /github/accounts` stored `GithubAccount.name` verbatim from the request body, and `meta_get_user` handed that string to downstream MCP consumers as if it were a GitHub identity. An attacker with a legitimate account could register **their own** valid PAT under a `name` claiming to be a different user — spoofing identity for anything that trusts the returned name.

## Fix

Identity is now resolved **from the credentials themselves**, never from user input.

- **New `github_accounts.verified_login` column** — written *only* from GitHub's own response. PAT auth → `GET /user`; App auth → `GET /app/installations/{id}`.
- **`create_account` / `update_account`** resolve `verified_login` from the stored credentials. Update re-verifies whenever any credential field (`access_token`, `app_id`, `installation_id`, `private_key`) changes; a name-only update leaves it untouched.
- **`validate_account`** now persists `verified_login`, doubling as the re-verification path for accounts created while GitHub was unreachable. It also uses the new identity resolver, fixing App-auth validation (the old `/user` call returns 403 for installation tokens).
- **`meta_get_user`** exposes `verified_login` alongside the now display-only `name`, with a comment telling consumers which field is trustworthy.
- **GitHub client**: added `get_authenticated_login()` and `get_app_installation()`; extracted `_generate_app_jwt()` from `_get_installation_token()`. Also de-duplicated four copies of the `GithubCredentials(...)` construction block into an `account_credentials()` helper.
- **Frontend**: `GithubAccount` type gains `verified_login`; the GitHub panel shows `verified as <login>` / `unverified` per account.

## Design notes

- **Verification failure is non-fatal.** If GitHub is unreachable (or the token is invalid) at create/update time, the account is still created with `verified_login = NULL` ("unverified") rather than coupling account creation to GitHub uptime. `validate_account` is the explicit re-verify path.
- **Existing production accounts** read `verified_login = NULL` until re-validated — fail-closed, which is the safe default.

## Testing

- Mocked unit tests in `test_github_sources.py`: spoofed-name is ignored, verification failure leaves `verified_login` NULL, credential-change re-verifies, name-only update preserves identity, `validate_account` persists/errors correctly. Existing create/update tests updated to mock `GithubClient`.
- The DB-backed suite could not be run in the dev sandbox (no Postgres) — CI will exercise it. Verified locally: syntax, imports, migration chain head, test collection (117 collected), and a direct unit-check of `get_authenticated_login()` branch logic.
- App-auth (`get_app_installation`) is mock-tested only; it needs a real GitHub App for live verification (best done via `validate_account` post-deploy).

🤖 Generated with [Claude Code](https://claude.com/claude-code)