### PR TITLE
test(frontend): consolidate inline mcpEnvelope helpers into the shared one (#89)

### DIFF
--- a/frontend/src/components/polls/PollCreate.test.tsx
+++ b/frontend/src/components/polls/PollCreate.test.tsx
@@ -11,10 +11,7 @@ import {
   mockResponse,
 } from '@/test/utils'
 import PollCreate from './PollCreate'
-
-function mcpEnvelope(payload: unknown) {
-  return { result: { content: [{ text: JSON.stringify(payload) }] } }
-}
+import { mcpEnvelopeJson } from '@/hooks/mcpEnvelope.testhelper'
 
 // upsert -> error toggle. Auth's /auth/me answered generically.
 function mockMcp(upsertResult: unknown | Error) {
@@ -27,7 +24,7 @@ function mockMcp(upsertResult: unknown | Error) {
       if (upsertResult instanceof Error) {
         return mockResponse({ status: 500, json: { detail: upsertResult.message } })
       }
-      return mockResponse({ json: mcpEnvelope(upsertResult) })
+      return mockResponse({ json: mcpEnvelopeJson(upsertResult) })
     }
     return mockResponse({ status: 404, json: { detail: 'not found' } })
   })

--- a/frontend/src/components/polls/PollEdit.test.tsx
+++ b/frontend/src/components/polls/PollEdit.test.tsx
@@ -12,10 +12,7 @@ import {
 } from '@/test/utils'
 import PollEdit from './PollEdit'
 import type { Poll } from '@/hooks/usePolls'
-
-function mcpEnvelope(payload: unknown) {
-  return { result: { content: [{ text: JSON.stringify(payload) }] } }
-}
+import { mcpEnvelopeJson } from '@/hooks/mcpEnvelope.testhelper'
 
 function makePoll(overrides: Partial<Poll> = {}): Poll {
   return {
@@ -51,7 +48,7 @@ function mockEdit({ loadResult = makePoll(), updateResult = {} }: EditMocks = {}
       if (updateResult instanceof Error) {
         return mockResponse({ status: 500, json: { detail: updateResult.message } })
       }
-      return mockResponse({ json: mcpEnvelope(updateResult) })
+      return mockResponse({ json: mcpEnvelopeJson(updateResult) })
     }
     // Public load: GET /polls/respond/:slug
     if (url.includes('/polls/respond/')) {

--- a/frontend/src/components/polls/PollList.test.tsx
+++ b/frontend/src/components/polls/PollList.test.tsx
@@ -10,12 +10,7 @@ import {
 } from '@/test/utils'
 import PollList from './PollList'
 import type { Poll } from '@/hooks/usePolls'
-
-// Build an MCP JSON-RPC success envelope. The hook expects
-// result.content[].text to be JSON-parseable.
-function mcpEnvelope(payload: unknown) {
-  return { result: { content: [{ text: JSON.stringify(payload) }] } }
-}
+import { mcpEnvelopeJson } from '@/hooks/mcpEnvelope.testhelper'
 
 function makePoll(overrides: Partial<Poll> = {}): Poll {
   return {
@@ -49,7 +44,7 @@ function mockMcp(handlers: Record<string, unknown | Error>) {
       if (payload instanceof Error) {
         return mockResponse({ status: 500, json: { detail: payload.message } })
       }
-      return mockResponse({ json: mcpEnvelope(payload) })
+      return mockResponse({ json: mcpEnvelopeJson(payload) })
     }
     return mockResponse({ status: 404, json: { detail: 'not found' } })
   })

--- a/frontend/src/components/polls/PollResults.test.tsx
+++ b/frontend/src/components/polls/PollResults.test.tsx
@@ -11,10 +11,7 @@ import {
 } from '@/test/utils'
 import PollResults from './PollResults'
 import type { Poll, PollResults as PollResultsType, SlotAggregation } from '@/hooks/usePolls'
-
-function mcpEnvelope(payload: unknown) {
-  return { result: { content: [{ text: JSON.stringify(payload) }] } }
-}
+import { mcpEnvelopeJson } from '@/hooks/mcpEnvelope.testhelper'
 
 function makePoll(overrides: Partial<Poll> = {}): Poll {
   return {
@@ -79,7 +76,7 @@ function mockResults({
       if (upsertResult instanceof Error) {
         return mockResponse({ status: 500, json: { detail: upsertResult.message } })
       }
-      return mockResponse({ json: mcpEnvelope(upsertResult) })
+      return mockResponse({ json: mcpEnvelopeJson(upsertResult) })
     }
     if (url.includes('/results')) {
       if (results instanceof Error) {

--- a/frontend/src/components/search/Search.test.tsx
+++ b/frontend/src/components/search/Search.test.tsx
@@ -1,18 +1,13 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest'
 import { screen, waitFor } from '@testing-library/react'
 import { renderWithRouter, mockFetch, mockResponse, setAuthCookies, clearCookies } from '@/test/utils'
+import { mcpEnvelopeJson } from '@/hooks/mcpEnvelope.testhelper'
 import Search from './Search'
 
 const navigateSpy = vi.fn()
 vi.mock('react-router-dom', async (importOriginal) => {
   const actual = await importOriginal<typeof import('react-router-dom')>()
   return { ...actual, useNavigate: () => navigateSpy }
-})
-
-const mcpEnvelope = (payloads: unknown[]) => ({
-  jsonrpc: '2.0',
-  id: 1,
-  result: { content: payloads.map((p) => ({ type: 'text', text: JSON.stringify(p) })) },
 })
 
 const schemas = {
@@ -26,11 +21,11 @@ const installFetch = (opts: { results?: unknown[]; searchFails?: boolean } = {})
       return mockResponse({ json: { user_id: 1, name: 'T', email: 't@e.com', user_type: 'human', scopes: ['*'] } })
     }
     if (url.includes('/mcp/meta_get_metadata_schemas')) {
-      return mockResponse({ json: mcpEnvelope([schemas]) })
+      return mockResponse({ json: mcpEnvelopeJson(schemas) })
     }
     if (url.includes('/mcp/core_search')) {
       if (opts.searchFails) return mockResponse({ status: 500, json: { detail: 'boom' } })
-      return mockResponse({ json: mcpEnvelope(opts.results ?? []) })
+      return mockResponse({ json: mcpEnvelopeJson(...(opts.results ?? [])) })
     }
     return mockResponse({ status: 404, json: { detail: 'nope' } })
   })

--- a/frontend/src/components/search/SearchForm.test.tsx
+++ b/frontend/src/components/search/SearchForm.test.tsx
@@ -1,15 +1,8 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest'
 import { screen, waitFor, fireEvent } from '@testing-library/react'
 import { renderWithUser, mockFetch, mockResponse, setAuthCookies, clearCookies } from '@/test/utils'
+import { mcpEnvelopeJson } from '@/hooks/mcpEnvelope.testhelper'
 import SearchForm from './SearchForm'
-
-// Build an MCP JSON-RPC envelope: useMCP reads response.text(), JSON.parses it,
-// then maps result.content[].text through JSON.parse.
-const mcpEnvelope = (payloads: unknown[]) => ({
-  jsonrpc: '2.0',
-  id: 1,
-  result: { content: payloads.map((p) => ({ type: 'text', text: JSON.stringify(p) })) },
-})
 
 const schemas = {
   blog: { schema: { author: { type: 'string', description: 'Author' } }, size: 0 },
@@ -23,10 +16,10 @@ const installFetch = (searchResults: unknown[] = []) =>
       return mockResponse({ json: { user_id: 1, name: 'T', email: 't@e.com', user_type: 'human', scopes: ['*'] } })
     }
     if (url.includes('/mcp/meta_get_metadata_schemas')) {
-      return mockResponse({ json: mcpEnvelope([schemas]) })
+      return mockResponse({ json: mcpEnvelopeJson(schemas) })
     }
     if (url.includes('/mcp/core_search')) {
-      return mockResponse({ json: mcpEnvelope(searchResults) })
+      return mockResponse({ json: mcpEnvelopeJson(...searchResults) })
     }
     return mockResponse({ status: 404, json: { detail: 'nope' } })
   })

--- a/frontend/src/components/sources/panels/BooksPanel.test.tsx
+++ b/frontend/src/components/sources/panels/BooksPanel.test.tsx
@@ -1,6 +1,7 @@
 import { describe, it, expect, beforeEach } from 'vitest'
 import { screen, waitFor } from '@testing-library/react'
 import { renderWithUser, mockFetchRoutes, setAuthCookies, clearCookies } from '@/test/utils'
+import { mcpResult, mcpEnvelopeJson } from '@/hooks/mcpEnvelope.testhelper'
 import { BooksPanel } from './BooksPanel'
 
 const authMe = { json: { user_id: 1, name: 'A', email: 'a@b.c', user_type: 'human', scopes: ['*'] } }
@@ -18,11 +19,6 @@ const book = {
   file_path: 'books/dune.epub',
 }
 
-// mcpCall unwraps result.content[].text via JSON.parse; listBooks then takes [0].
-const mcpEnvelope = (payload: unknown) => ({
-  json: { jsonrpc: '2.0', id: 1, result: { content: [{ text: JSON.stringify(payload) }] } },
-})
-
 beforeEach(() => {
   clearCookies()
   setAuthCookies()
@@ -30,14 +26,14 @@ beforeEach(() => {
 
 describe('BooksPanel load states', () => {
   it('shows the empty state when no books are indexed', async () => {
-    mockFetchRoutes({ '/mcp/books_list_books': mcpEnvelope([]), '/auth/me': authMe, __default: { json: {} } })
+    mockFetchRoutes({ '/mcp/books_list_books': mcpResult([]), '/auth/me': authMe, __default: { json: {} } })
     renderWithUser(<BooksPanel />)
     expect(screen.getByText('Loading...')).toBeInTheDocument()
     await waitFor(() => expect(screen.getByText('No books indexed yet')).toBeInTheDocument())
   })
 
   it('renders a book with its metadata and a download link', async () => {
-    mockFetchRoutes({ '/mcp/books_list_books': mcpEnvelope([book]), '/auth/me': authMe, __default: { json: {} } })
+    mockFetchRoutes({ '/mcp/books_list_books': mcpResult([book]), '/auth/me': authMe, __default: { json: {} } })
     renderWithUser(<BooksPanel />)
     await waitFor(() => expect(screen.getByText('Dune')).toBeInTheDocument())
     expect(screen.getByText('by Frank Herbert')).toBeInTheDocument()
@@ -53,7 +49,7 @@ describe('BooksPanel load states', () => {
   })
 
   it('renders a plain title (no link) when file_path is missing', async () => {
-    mockFetchRoutes({ '/mcp/books_list_books': mcpEnvelope([{ ...book, file_path: null }]), '/auth/me': authMe, __default: { json: {} } })
+    mockFetchRoutes({ '/mcp/books_list_books': mcpResult([{ ...book, file_path: null }]), '/auth/me': authMe, __default: { json: {} } })
     renderWithUser(<BooksPanel />)
     await waitFor(() => expect(screen.getByText('Dune')).toBeInTheDocument())
     expect(screen.queryByRole('link', { name: 'Dune' })).not.toBeInTheDocument()
@@ -69,7 +65,7 @@ describe('BooksPanel load states', () => {
 describe('BooksPanel upload flow', () => {
   it('uploads a selected file and shows the success banner', async () => {
     const mock = mockFetchRoutes({
-      '/mcp/books_list_books': mcpEnvelope([]),
+      '/mcp/books_list_books': mcpResult([]),
       '/books/upload': { json: { task_id: 't1', status: 'queued' } },
       '/auth/me': authMe,
       __default: { json: {} },
@@ -89,7 +85,7 @@ describe('BooksPanel upload flow', () => {
   })
 
   it('shows the error banner when the upload fails', async () => {
-    const mock = mockFetchRoutes({ '/mcp/books_list_books': mcpEnvelope([]), '/auth/me': authMe, __default: { json: {} } })
+    const mock = mockFetchRoutes({ '/mcp/books_list_books': mcpResult([]), '/auth/me': authMe, __default: { json: {} } })
     mock.mockImplementation(async (input) => {
       const url = String(input)
       if (url.includes('/books/upload')) {
@@ -99,8 +95,8 @@ describe('BooksPanel upload flow', () => {
         ok: true,
         status: 200,
         headers: new Headers(),
-        json: async () => mcpEnvelope([]).json,
-        text: async () => JSON.stringify(mcpEnvelope([]).json),
+        json: async () => mcpEnvelopeJson([]),
+        text: async () => JSON.stringify(mcpEnvelopeJson([])),
       } as unknown as Response
     })
     const { user } = renderWithUser(<BooksPanel />)

--- a/frontend/src/hooks/mcpEnvelope.testhelper.ts
+++ b/frontend/src/hooks/mcpEnvelope.testhelper.ts
@@ -1,56 +1,64 @@
 import type { MockResponseInit } from '@/test/utils'
 
+// `useMCP`'s `parseJsonResponse` (used by useTelemetry/useDiscord and others)
+// throws unless the response advertises a JSON content-type, so every
+// envelope-bearing MockResponseInit declares it. `mcpCall` itself reads
+// `response.text()` regardless, so this header is harmless for the plain path.
+const JSON_HEADERS = { 'content-type': 'application/json' }
+
+function toContentItem(payload: unknown) {
+  return {
+    type: 'text',
+    text: typeof payload === 'string' ? payload : JSON.stringify(payload),
+  }
+}
+
 /**
- * Build a MockResponseInit whose body is a JSON-RPC envelope wrapping the given
- * content payloads. Each payload becomes one `content` item whose `text` is the
- * JSON-stringified value, mirroring how the MCP server streams tool results.
- *
- * The hooks' `mcpCall` reads the response via `response.text()` (no
- * `text/event-stream` content-type) then `JSON.parse`s it, and finally
- * `JSON.parse`s each `content[i].text`. So the hook receives the parsed
- * payloads as its result array.
+ * Build the raw JSON-RPC envelope OBJECT wrapping the given content payloads
+ * (each becomes one `content[i].text`, JSON-stringified — mirroring how the
+ * MCP server streams tool results). Use this when a test builds its own
+ * `Response`/`mockFetch` by hand and needs the body object; use `mcpResult`
+ * when you want a ready-to-route `MockResponseInit`.
+ */
+export function mcpEnvelopeJson(...payloads: unknown[]) {
+  return {
+    jsonrpc: '2.0',
+    id: 1,
+    result: { content: payloads.map(toContentItem) },
+  }
+}
+
+/**
+ * A `MockResponseInit` whose body is the JSON-RPC envelope from
+ * `mcpEnvelopeJson`. `mcpCall` finally `JSON.parse`s each `content[i].text`,
+ * so the hook receives the parsed payloads as its result array.
  */
 export function mcpResult(...payloads: unknown[]): MockResponseInit {
+  return { status: 200, headers: JSON_HEADERS, json: mcpEnvelopeJson(...payloads) }
+}
+
+/** Raw tool-error envelope object (result.isError = true). */
+export function mcpToolErrorJson(message: string) {
   return {
-    status: 200,
-    json: {
-      jsonrpc: '2.0',
-      id: 1,
-      result: {
-        content: payloads.map((p) => ({
-          type: 'text',
-          text: typeof p === 'string' ? p : JSON.stringify(p),
-        })),
-      },
-    },
+    jsonrpc: '2.0',
+    id: 1,
+    result: { isError: true, content: [{ type: 'text', text: message }] },
   }
 }
 
 /** Build a JSON-RPC tool-error envelope (result.isError = true). */
 export function mcpToolError(message: string): MockResponseInit {
-  return {
-    status: 200,
-    json: {
-      jsonrpc: '2.0',
-      id: 1,
-      result: {
-        isError: true,
-        content: [{ type: 'text', text: message }],
-      },
-    },
-  }
+  return { status: 200, headers: JSON_HEADERS, json: mcpToolErrorJson(message) }
+}
+
+/** Raw JSON-RPC error envelope object (top-level error). */
+export function mcpRpcErrorJson(message: string, code = -32000) {
+  return { jsonrpc: '2.0', id: 1, error: { code, message } }
 }
 
 /** Build a JSON-RPC error envelope (top-level error object). */
 export function mcpRpcError(message: string, code = -32000): MockResponseInit {
-  return {
-    status: 200,
-    json: {
-      jsonrpc: '2.0',
-      id: 1,
-      error: { code, message },
-    },
-  }
+  return { status: 200, headers: JSON_HEADERS, json: mcpRpcErrorJson(message, code) }
 }
 
 /** The fetch calls that target an `/mcp/<method>` endpoint, in order. */

--- a/frontend/src/hooks/useBooks.test.ts
+++ b/frontend/src/hooks/useBooks.test.ts
@@ -8,24 +8,12 @@ import {
   setAuthCookies,
   clearCookies,
 } from '@/test/utils'
+import { mcpResult } from './mcpEnvelope.testhelper'
 
 beforeEach(() => {
   clearCookies()
   setAuthCookies()
 })
-
-function mcpResult(...values: unknown[]): MockResponseInit {
-  return {
-    json: {
-      jsonrpc: '2.0',
-      id: 1,
-      result: {
-        content: values.map((v) => ({ type: 'text', text: JSON.stringify(v) })),
-        isError: false,
-      },
-    },
-  }
-}
 
 function routeMcp(resp: MockResponseInit) {
   return mockFetch(async (input) => {

--- a/frontend/src/hooks/useCalendar.test.ts
+++ b/frontend/src/hooks/useCalendar.test.ts
@@ -4,23 +4,10 @@ import { useCalendar, CalendarEvent } from './useCalendar'
 import {
   mockFetch,
   mockResponse,
-  MockResponseInit,
   setAuthCookies,
   clearCookies,
 } from '@/test/utils'
-
-function mcpResult(...values: unknown[]): MockResponseInit {
-  return {
-    json: {
-      jsonrpc: '2.0',
-      id: 1,
-      result: {
-        content: values.map((v) => ({ type: 'text', text: JSON.stringify(v) })),
-        isError: false,
-      },
-    },
-  }
-}
+import { mcpResult } from './mcpEnvelope.testhelper'
 
 // Each /mcp call gets a fresh response built from `events` so cache misses fetch.
 function routeMcpDynamic(makeEvents: () => CalendarEvent[]) {

--- a/frontend/src/hooks/useDiscord.test.ts
+++ b/frontend/src/hooks/useDiscord.test.ts
@@ -2,18 +2,15 @@ import { describe, it, expect, beforeEach } from 'vitest'
 import { renderHook } from '@testing-library/react'
 import { useDiscord } from './useDiscord'
 import { setAuthCookies, clearCookies, mockFetch, mockResponse } from '@/test/utils'
+import { mcpEnvelopeJson } from './mcpEnvelope.testhelper'
 
-// Build the JSON-RPC tools/call body that useMCP.mcpCall expects:
-// { result: { content: [ { text: JSON.stringify(payload) } ] } }
-function mcpResult(payload: unknown) {
+// Build a full Response wrapping the JSON-RPC tools/call envelope that
+// useMCP.mcpCall expects (single payload → one content item).
+function mcpResponse(payload: unknown) {
   return mockResponse({
     status: 200,
     headers: { 'content-type': 'application/json' },
-    text: JSON.stringify({
-      jsonrpc: '2.0',
-      id: 1,
-      result: { content: [{ type: 'text', text: JSON.stringify(payload) }] },
-    }),
+    text: JSON.stringify(mcpEnvelopeJson(payload)),
   })
 }
 
@@ -219,7 +216,7 @@ describe('useDiscord servers', () => {
 describe('useDiscord channels (MCP-backed list)', () => {
   it('listChannels transforms the MCP response into DiscordChannel objects', async () => {
     mockFetch(async () =>
-      mcpResult({
+      mcpResponse({
         channels: [
           { id: 12345, name: 'general', type: 'text', server_id: 999, collect_messages: true },
         ],
@@ -241,7 +238,7 @@ describe('useDiscord channels (MCP-backed list)', () => {
 
   it('listChannels coerces a null server_id to null (not the string "null")', async () => {
     mockFetch(async () =>
-      mcpResult({
+      mcpResponse({
         channels: [{ id: 'c1', name: 'dm', type: 'dm', server_id: null, collect_messages: false }],
       }),
     )
@@ -251,7 +248,7 @@ describe('useDiscord channels (MCP-backed list)', () => {
   })
 
   it('listChannels passes server_id and server_name as MCP arguments', async () => {
-    const fetchMock = mockFetch(async () => mcpResult({ channels: [] }))
+    const fetchMock = mockFetch(async () => mcpResponse({ channels: [] }))
     await setup().listChannels('999', 'My Server')
     const { init } = callTo(fetchMock, '/mcp/discord_list_channels')
     const body = JSON.parse(init?.body as string)
@@ -259,13 +256,13 @@ describe('useDiscord channels (MCP-backed list)', () => {
   })
 
   it('listChannels returns [] when the MCP payload lacks a channels key', async () => {
-    mockFetch(async () => mcpResult({ unexpected: true }))
+    mockFetch(async () => mcpResponse({ unexpected: true }))
     const channels = await setup().listChannels()
     expect(channels).toEqual([])
   })
 
   it('listChannels treats a missing channels array as empty', async () => {
-    mockFetch(async () => mcpResult({ channels: null }))
+    mockFetch(async () => mcpResponse({ channels: null }))
     const channels = await setup().listChannels()
     expect(channels).toEqual([])
   })

--- a/frontend/src/hooks/useJournal.test.ts
+++ b/frontend/src/hooks/useJournal.test.ts
@@ -8,24 +8,12 @@ import {
   setAuthCookies,
   clearCookies,
 } from '@/test/utils'
+import { mcpResult } from './mcpEnvelope.testhelper'
 
 beforeEach(() => {
   clearCookies()
   setAuthCookies()
 })
-
-function mcpResult(...values: unknown[]): MockResponseInit {
-  return {
-    json: {
-      jsonrpc: '2.0',
-      id: 1,
-      result: {
-        content: values.map((v) => ({ type: 'text', text: JSON.stringify(v) })),
-        isError: false,
-      },
-    },
-  }
-}
 
 function routeMcp(resp: MockResponseInit) {
   return mockFetch(async (input) => {

--- a/frontend/src/hooks/useReports.test.ts
+++ b/frontend/src/hooks/useReports.test.ts
@@ -8,24 +8,12 @@ import {
   setAuthCookies,
   clearCookies,
 } from '@/test/utils'
+import { mcpResult } from './mcpEnvelope.testhelper'
 
 beforeEach(() => {
   clearCookies()
   setAuthCookies()
 })
-
-function mcpResult(...values: unknown[]): MockResponseInit {
-  return {
-    json: {
-      jsonrpc: '2.0',
-      id: 1,
-      result: {
-        content: values.map((v) => ({ type: 'text', text: JSON.stringify(v) })),
-        isError: false,
-      },
-    },
-  }
-}
 
 function routeMcp(resp: MockResponseInit) {
   return mockFetch(async (input) => {

--- a/frontend/src/hooks/useScheduledTasks.test.ts
+++ b/frontend/src/hooks/useScheduledTasks.test.ts
@@ -8,26 +8,12 @@ import {
   setAuthCookies,
   clearCookies,
 } from '@/test/utils'
+import { mcpResult } from './mcpEnvelope.testhelper'
 
 beforeEach(() => {
   clearCookies()
   setAuthCookies()
 })
-
-// Build a JSON-RPC tools/call response whose content items JSON-encode `values`.
-// mcpCall returns content.map(item => JSON.parse(item.text)), so result[0] === values[0].
-function mcpResult(...values: unknown[]): MockResponseInit {
-  return {
-    json: {
-      jsonrpc: '2.0',
-      id: 1,
-      result: {
-        content: values.map((v) => ({ type: 'text', text: JSON.stringify(v) })),
-        isError: false,
-      },
-    },
-  }
-}
 
 // Route /auth/me to {} and all /mcp/* calls to the supplied response.
 function routeMcp(resp: MockResponseInit) {


### PR DESCRIPTION
Closes #89 — the follow-up agreed during #88's review.

## What

Removes the 13 inline copies of the JSON-RPC MCP-envelope construction in the test suite, centralizing them on `frontend/src/hooks/mcpEnvelope.testhelper.ts`.

**Shared helper, extended to cover all three usage shapes:**
- `mcpResult` / `mcpToolError` / `mcpRpcError` now emit a `content-type: application/json` header, so they satisfy `parseJsonResponse` consumers (`useTelemetry`/`useDiscord`) as well as the plain `mcpCall` path. (Harmless for the plain path — it reads `response.text()` regardless.)
- New raw-object variants `mcpEnvelopeJson` / `mcpToolErrorJson` / `mcpRpcErrorJson` for tests that build their own `Response` inside a hand-rolled `mockFetch`.

**13 files migrated, by shape:**
| shape | → | files |
|---|---|---|
| raw envelope object | `mcpEnvelopeJson` | PollCreate, PollEdit, PollList, PollResults, Search, SearchForm |
| `MockResponseInit` | `mcpResult` | useBooks, useCalendar, useReports, useJournal, useScheduledTasks, BooksPanel |
| full `Response` | `mockResponse` + shared envelope | useDiscord (its local Response wrapper renamed `mcpResult`→`mcpResponse` so it no longer shadows the shared name) |

## Guarantees
- **No behavior change** — no app source, assertions, mocked data, or routing keys were touched; only envelope-construction plumbing. The array-vs-variadic mapping (`mcpEnvelope([a,b])` → `mcpEnvelopeJson(a, b)`) was handled per call site.
- **No inline `mcpEnvelope`/`mcpResult` definitions remain** in any test file.
- Full suite **1382 passing**, eslint clean, coverage structurally unchanged (the helper stays excluded via `src/**/*.testhelper.*`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)