### PR TITLE
feat(search): unify filter translation into one declarative registry

### DIFF
--- a/frontend/src/components/scheduled-tasks/ScheduledTasks.test.tsx
+++ b/frontend/src/components/scheduled-tasks/ScheduledTasks.test.tsx
@@ -232,7 +232,7 @@ describe('ScheduledTasks', () => {
     await waitFor(() => expect(screen.getByText('notif task')).toBeInTheDocument())
     await user.click(screen.getByRole('button', { name: 'Edit' }))
     await user.selectOptions(screen.getByRole('combobox'), 'email')
-    await user.type(screen.getByPlaceholderText('channel or email'), 'a@b.c')
+    await user.type(screen.getByPlaceholderText('you@example.com'), 'a@b.c')
     await user.click(screen.getByRole('button', { name: 'Save' }))
     await waitFor(() =>
       expect(updateTask).toHaveBeenCalledWith('notif', expect.objectContaining({

--- a/src/memory/api/MCP/servers/core.py
+++ b/src/memory/api/MCP/servers/core.py
@@ -171,6 +171,56 @@ def _build_filters_section() -> str:
     return "\n".join(lines)
 
 
+def _build_list_items_description() -> str:
+    """Build dynamic description for the list_items tool.
+
+    Reuses :func:`_build_filters_section` (driven by SEARCH_FILTERS) so the
+    accepted content-metadata filters are documented identically to
+    search_knowledge_base instead of being hand-maintained. Mirrors how
+    _build_search_description injects the same section.
+    """
+    return textwrap.dedent(
+        """
+        List items without semantic search - for systematic enumeration.
+        Use for reviewing all items matching criteria, not finding best matches.
+
+        Args:
+            modalities: Filter by type: mail, blog, book, forum, photo, comic, etc. (empty = all)
+            {filters_section}
+            Observation-only filters (observation_types, min_confidences) are
+            rejected here - use search_observations for those.
+            limit: Max results per page (default 50, max 200)
+            offset: Skip first N results for pagination
+            sort_by: Sort field - "inserted_at", "size", or "id" (default: inserted_at)
+            sort_order: "asc" or "desc" (default: desc)
+            include_metadata: Include full as_payload() metadata (default True)
+
+        Returns: {{items: [...], total: int, has_more: bool}}"""
+    ).format(filters_section=_build_filters_section())
+
+
+def _build_count_items_description() -> str:
+    """Build dynamic description for the count_items tool.
+
+    Reuses :func:`_build_filters_section` so the documented filters always match
+    list_items and search_knowledge_base (the three share the same filter set).
+    """
+    return textwrap.dedent(
+        """
+        Count items matching criteria without retrieving them.
+        Use to understand scope before systematic review.
+
+        Args:
+            modalities: Filter by type (empty = all)
+            {filters_section}
+            Observation-only filters (observation_types, min_confidences) are
+            rejected here - use search_observations for those. count_items and
+            list_items apply the identical filter set, so their totals always agree.
+
+        Returns: {{total: int, by_modality: {{mail: 100, blog: 50, ...}}}}"""
+    ).format(filters_section=_build_filters_section())
+
+
 def _build_search_description() -> str:
     """Build dynamic description for search_knowledge_base tool."""
     modalities = _get_available_modalities()
@@ -786,7 +836,7 @@ def apply_item_filters(query, modalities: set[str], filters: MCPSearchFilters):
     return query
 
 
-@core_mcp.tool()
+@core_mcp.tool(description=_build_list_items_description())
 @visible_when(require_scopes(SCOPE_READ))
 async def list_items(
     modalities: set[str] = set(),
@@ -797,24 +847,7 @@ async def list_items(
     sort_order: str = "desc",
     include_metadata: bool = True,
 ) -> dict:
-    """
-    List items without semantic search - for systematic enumeration.
-    Use for reviewing all items matching criteria, not finding best matches.
-
-    Args:
-        modalities: Filter by type: mail, blog, book, forum, photo, comic, etc. (empty = all)
-        filters: Same content-metadata filters as search_knowledge_base (tags,
-            min_size, max_size, sender, recipients, subject, sent_at, etc.).
-            Observation-only filters (observation_types, min_confidences) are
-            rejected here — use search_observations for those.
-        limit: Max results per page (default 50, max 200)
-        offset: Skip first N results for pagination
-        sort_by: Sort field - "inserted_at", "size", or "id" (default: inserted_at)
-        sort_order: "asc" or "desc" (default: desc)
-        include_metadata: Include full as_payload() metadata (default True)
-
-    Returns: {items: [...], total: int, has_more: bool}
-    """
+    """List items without semantic search. See tool description for full parameter docs."""
     limit = min(limit, 200)
     if sort_by not in ("inserted_at", "size", "id"):
         sort_by = "inserted_at"
@@ -873,25 +906,13 @@ async def list_items(
         }
 
 
-@core_mcp.tool()
+@core_mcp.tool(description=_build_count_items_description())
 @visible_when(require_scopes(SCOPE_READ))
 async def count_items(
     modalities: set[str] = set(),
     filters: MCPSearchFilters = {},
 ) -> dict:
-    """
-    Count items matching criteria without retrieving them.
-    Use to understand scope before systematic review.
-
-    Args:
-        modalities: Filter by type (empty = all)
-        filters: Same content-metadata filters as search_knowledge_base.
-            Observation-only filters (observation_types, min_confidences) are
-            rejected here — use search_observations for those. count_items and
-            list_items apply the identical filter set, so their totals always agree.
-
-    Returns: {total: int, by_modality: {mail: 100, blog: 50, ...}}
-    """
+    """Count items matching criteria. See tool description for full parameter docs."""
     # Get access filter for current user
     access_filter = get_current_user_access_filter()
 

--- a/src/memory/api/MCP/servers/core.py
+++ b/src/memory/api/MCP/servers/core.py
@@ -12,7 +12,7 @@ from fastmcp import FastMCP
 from fastmcp.server.dependencies import get_access_token
 from PIL import Image
 from pydantic import BaseModel
-from sqlalchemy import Text
+from sqlalchemy import Text, exists, func, or_, select
 from sqlalchemy import cast as sql_cast
 from sqlalchemy.dialects.postgresql import ARRAY
 from sqlalchemy.orm import selectinload
@@ -37,6 +37,11 @@ from memory.common.scopes import (
     SCOPE_READ,
 )
 from memory.api.auth import lookup_api_key
+from memory.api.search.filters import (
+    FILTER_REGISTRY,
+    apply_registry_filters_sql,
+    reject_unknown_filter_keys,
+)
 from memory.api.search.search import search as search_base
 from memory.api.search.types import MCPSearchFilters, SearchConfig, SearchFilters
 from memory.common import extract, paths, settings
@@ -46,23 +51,15 @@ from memory.common.collections import ALL_COLLECTIONS, OBSERVATION_COLLECTIONS
 from memory.common.db.connection import make_session
 from memory.common.db.models import (
     AgentObservation,
-    BlogPost,
-    EmailAttachment,
-    GoogleDoc,
-    MailMessage,
     SourceItem,
     UserSession,
 )
+from memory.common.db.models.source_item import source_item_people
 from memory.common.db.models.journal import JournalEntry, build_journal_access_filter
 from memory.common.formatters import observation
 
 
 logger = logging.getLogger(__name__)
-
-
-def escape_like(s: str) -> str:
-    """Escape ILIKE metacharacters to prevent pattern injection."""
-    return s.replace("\\", "\\\\").replace("%", "\\%").replace("_", "\\_")
 
 
 def get_current_user_access_filter() -> AccessFilter | None:
@@ -723,6 +720,70 @@ def apply_access_control_to_query(query, access_filter: AccessFilter | None, ses
     return apply_access_filter_to_query(query, access_filter)
 
 
+# Special filter keys that item enumeration handles directly (not via the
+# shared FILTER_REGISTRY). created_at is scoped to SourceItem.inserted_at here
+# — distinct from BM25's Chunk.created_at, see SPECIAL_FILTER_KEYS in
+# search.filters. Everything else (registry keys) is folded on declaratively.
+ITEM_SPECIAL_FILTER_KEYS = frozenset(
+    {"source_ids", "min_created_at", "max_created_at", "person_id"}
+)
+
+# Keys accepted by item enumeration: the declarative registry plus the special
+# keys handled inline below. observation_types/min_confidences are observation-
+# search concepts (AgentObservation columns / ConfidenceScore), handled by
+# filter_observation_source_ids on its own query — they have no meaning for a
+# SourceItem enumeration, so they are NOT accepted here and reject loudly rather
+# than silently returning an unfiltered count. Any other non-empty key is
+# likewise rejected so list_items and count_items can never disagree about a
+# filter one of them forgot.
+ITEM_ALLOWED_FILTER_KEYS = set(FILTER_REGISTRY) | ITEM_SPECIAL_FILTER_KEYS
+
+
+def apply_item_filters(query, modalities: set[str], filters: MCPSearchFilters):
+    """Apply modality + MCPSearchFilters constraints to a SourceItem query.
+
+    Shared by list_items and count_items so the two can never drift. Registry
+    filters (mail/blog/doc metadata) are folded on via
+    :func:`apply_registry_filters_sql`, which joins each joined-inheritance
+    subclass table on ``SourceItem.id``. A query that combines filters from two
+    different subclasses can never match a row (an item is exactly one
+    subclass); that is the correct outcome.
+
+    Any provided filter key not in :data:`ITEM_ALLOWED_FILTER_KEYS` raises
+    ValueError instead of being silently dropped.
+    """
+    reject_unknown_filter_keys(filters, allowed=ITEM_ALLOWED_FILTER_KEYS)
+
+    if modalities:
+        query = query.filter(SourceItem.modality.in_(modalities))
+
+    # Special keys scoped to SourceItem itself.
+    if source_ids := filters.get("source_ids"):
+        query = query.filter(SourceItem.id.in_(source_ids))
+    if min_created_at := filters.get("min_created_at"):
+        query = query.filter(SourceItem.inserted_at >= min_created_at)
+    if max_created_at := filters.get("max_created_at"):
+        query = query.filter(SourceItem.inserted_at <= max_created_at)
+
+    # Declarative content-metadata filters (tags/size/mail/blog/doc).
+    query = apply_registry_filters_sql(query, filters)
+
+    if (person_id := filters.get("person_id")) is not None:
+        person_associated = exists(
+            select(source_item_people.c.source_item_id)
+            .where(source_item_people.c.source_item_id == SourceItem.id)
+            .where(source_item_people.c.person_id == person_id)
+        )
+        no_people = ~exists(
+            select(source_item_people.c.source_item_id).where(
+                source_item_people.c.source_item_id == SourceItem.id
+            )
+        )
+        query = query.filter(or_(no_people, person_associated))
+
+    return query
+
+
 @core_mcp.tool()
 @visible_when(require_scopes(SCOPE_READ))
 async def list_items(
@@ -739,8 +800,11 @@ async def list_items(
     Use for reviewing all items matching criteria, not finding best matches.
 
     Args:
-        modalities: Filter by type: email, blog, book, forum, photo, comic, etc. (empty = all)
-        filters: Same filters as search_knowledge_base (tags, min_size, max_size, etc.)
+        modalities: Filter by type: mail, blog, book, forum, photo, comic, etc. (empty = all)
+        filters: Same content-metadata filters as search_knowledge_base (tags,
+            min_size, max_size, sender, recipients, subject, sent_at, etc.).
+            Observation-only filters (observation_types, min_confidences) are
+            rejected here — use search_observations for those.
         limit: Max results per page (default 50, max 200)
         offset: Skip first N results for pagination
         sort_by: Sort field - "inserted_at", "size", or "id" (default: inserted_at)
@@ -760,42 +824,8 @@ async def list_items(
 
     with make_session() as session:
         query = session.query(SourceItem).filter(SourceItem.embed_status == "STORED")
-
-        # Apply access control filter
         query = apply_access_control_to_query(query, access_filter, session)
-
-        # Filter by modalities
-        if modalities:
-            query = query.filter(SourceItem.modality.in_(modalities))
-
-        # Apply filters
-        if tags := filters.get("tags"):
-            query = query.filter(SourceItem.tags.op("&&")(sql_cast(tags, ARRAY(Text))))
-        if min_size := filters.get("min_size"):
-            query = query.filter(SourceItem.size >= min_size)
-        if max_size := filters.get("max_size"):
-            query = query.filter(SourceItem.size <= max_size)
-        if source_ids := filters.get("source_ids"):
-            query = query.filter(SourceItem.id.in_(source_ids))
-        if min_created_at := filters.get("min_created_at"):
-            query = query.filter(SourceItem.inserted_at >= min_created_at)
-        if max_created_at := filters.get("max_created_at"):
-            query = query.filter(SourceItem.inserted_at <= max_created_at)
-
-        # Metadata filters - require joining specific tables
-        if folder_path := filters.get("folder_path"):
-            escaped = escape_like(folder_path)
-            query = query.join(GoogleDoc).filter(
-                GoogleDoc.folder_path.ilike(f"%{escaped}%", escape="\\")
-            )
-        if sender := filters.get("sender"):
-            query = (
-                query.join(EmailAttachment)
-                .join(MailMessage, EmailAttachment.mail_message_id == MailMessage.id)
-                .filter(MailMessage.sender == sender)
-            )
-        if domain := filters.get("domain"):
-            query = query.join(BlogPost).filter(BlogPost.domain == domain)
+        query = apply_item_filters(query, modalities, filters)
 
         # Get total count
         total = query.count()
@@ -853,12 +883,13 @@ async def count_items(
 
     Args:
         modalities: Filter by type (empty = all)
-        filters: Same filters as search_knowledge_base
+        filters: Same content-metadata filters as search_knowledge_base.
+            Observation-only filters (observation_types, min_confidences) are
+            rejected here — use search_observations for those. count_items and
+            list_items apply the identical filter set, so their totals always agree.
 
-    Returns: {total: int, by_modality: {email: 100, blog: 50, ...}}
+    Returns: {total: int, by_modality: {mail: 100, blog: 50, ...}}
     """
-    from sqlalchemy import func as sql_func
-
     # Get access filter for current user
     access_filter = get_current_user_access_filter()
 
@@ -866,34 +897,15 @@ async def count_items(
         base_query = session.query(SourceItem).filter(
             SourceItem.embed_status == "STORED"
         )
-
-        # Apply access control filter
         base_query = apply_access_control_to_query(base_query, access_filter, session)
-
-        # Apply filters
-        if modalities:
-            base_query = base_query.filter(SourceItem.modality.in_(modalities))
-        if tags := filters.get("tags"):
-            base_query = base_query.filter(
-                SourceItem.tags.op("&&")(sql_cast(tags, ARRAY(Text)))
-            )
-        if min_size := filters.get("min_size"):
-            base_query = base_query.filter(SourceItem.size >= min_size)
-        if max_size := filters.get("max_size"):
-            base_query = base_query.filter(SourceItem.size <= max_size)
-        if source_ids := filters.get("source_ids"):
-            base_query = base_query.filter(SourceItem.id.in_(source_ids))
-        if min_created_at := filters.get("min_created_at"):
-            base_query = base_query.filter(SourceItem.inserted_at >= min_created_at)
-        if max_created_at := filters.get("max_created_at"):
-            base_query = base_query.filter(SourceItem.inserted_at <= max_created_at)
+        base_query = apply_item_filters(base_query, modalities, filters)
 
         # Get total
         total = base_query.count()
 
-        # Get counts by modality
+        # Get counts by modality on the same filtered query
         by_modality_query = base_query.with_entities(
-            SourceItem.modality, sql_func.count(SourceItem.id)
+            SourceItem.modality, func.count(SourceItem.id)
         ).group_by(SourceItem.modality)
 
         by_modality = {row[0]: row[1] for row in by_modality_query.all()}

--- a/src/memory/api/MCP/servers/scheduler.py
+++ b/src/memory/api/MCP/servers/scheduler.py
@@ -379,7 +379,7 @@ async def upsert(
             task.notification_target = resolve_and_validate_target(
                 session, user_id, task.notification_channel, notification_target
             )
-        elif channel_changed and task.notification_target:
+        elif channel_changed and task.notification_target and task.notification_channel:
             # The stored target was validated for the OLD channel; a channel
             # change must re-resolve it (or surface a clear error) rather than
             # leave a target that silently breaks at dispatch.

--- a/src/memory/api/search/bm25.py
+++ b/src/memory/api/search/bm25.py
@@ -12,12 +12,24 @@ import re
 from sqlalchemy import func, text, or_, exists, select
 
 from memory.api.search.embeddings import require_access_filter
+from memory.api.search.filters import (
+    FILTER_REGISTRY,
+    SPECIAL_FILTER_KEYS,
+    apply_registry_filters_sql,
+    is_empty_value,
+    reject_unknown_filter_keys,
+)
 from memory.api.search.types import SearchFilters
 from memory.common import extract
 from memory.common.access_control import apply_access_filter_to_query
 from memory.common.db.connection import make_session
 from memory.common.db.models import Chunk, ConfidenceScore, SourceItem
 from memory.common.db.models.source_item import source_item_people
+
+# BM25 accepts every logical filter: the declarative registry plus the
+# hand-coded special keys (access/person/source_ids/confidence/observation +
+# the created_at divergence). Anything else is a programming error.
+BM25_ALLOWED_FILTER_KEYS = set(FILTER_REGISTRY) | SPECIAL_FILTER_KEYS
 
 logger = logging.getLogger(__name__)
 
@@ -90,6 +102,7 @@ async def search_bm25(
             for the BM25 layer.
     """
     filters = require_access_filter(filters, "search_bm25")
+    reject_unknown_filter_keys(filters, allowed=BM25_ALLOWED_FILTER_KEYS)
     tsquery = build_tsquery(query)
     if not tsquery:
         return {}
@@ -111,16 +124,28 @@ async def search_bm25(
             Chunk.search_vector.op("@@")(func.to_tsquery("english", tsquery)),
         )
 
-        # Join with SourceItem if we need size filters, access control, or person filter
+        # Join with SourceItem if we need access control, person filter, or any
+        # registry filter (size/tags on SourceItem + mail/blog/doc subclass
+        # joins all hang off SourceItem.id).
         access_filter = filters.get("access_filter")
         person_id = filters.get("person_id")
+        # Use is_empty_value (not truthiness) so a legitimate 0 bound — e.g.
+        # min_size=0 — still triggers the join. Plain truthiness would skip the
+        # join while apply_registry_filters_sql still emits `source_item.size
+        # >= 0`, producing an uncorrelated cross join that also escapes the
+        # source-join-based access filter.
+        has_registry_filter = any(
+            not is_empty_value(filters.get(k)) for k in FILTER_REGISTRY
+        )
         needs_source_join = (
-            any(filters.get(k) for k in ["min_size", "max_size"])
+            has_registry_filter
             or access_filter is not None
             or person_id is not None
         )
 
-        # Date filters on Chunk.created_at
+        # created_at is scoped to Chunk.created_at here (NOT SourceItem.inserted_at
+        # — see SPECIAL_FILTER_KEYS in search.filters for why the two backends
+        # intentionally differ).
         if min_created_at := filters.get("min_created_at"):
             items_query = items_query.filter(Chunk.created_at >= min_created_at)
         if max_created_at := filters.get("max_created_at"):
@@ -135,6 +160,14 @@ async def search_bm25(
             items_query = apply_access_filter_to_query(
                 items_query, access_filter
             )
+
+        # Declarative content-metadata filters (tags/size/mail/blog/doc). The
+        # joins are 1:1 on id so rank/order is unaffected. SourceItem is
+        # already joined above; pass it as pre-joined so registry helper only
+        # adds the subclass joins.
+        items_query = apply_registry_filters_sql(
+            items_query, filters, joined={SourceItem}
+        )
 
         # Apply person filter (requires source join)
         # Include items where: no people associations exist OR person is associated
@@ -156,12 +189,6 @@ async def search_bm25(
 
         if source_ids := filters.get("source_ids"):
             items_query = items_query.filter(Chunk.source_id.in_(source_ids))
-
-        # Size filters
-        if min_size := filters.get("min_size"):
-            items_query = items_query.filter(SourceItem.size >= min_size)
-        if max_size := filters.get("max_size"):
-            items_query = items_query.filter(SourceItem.size <= max_size)
 
         # Observation type filter - restricts to specific collection types
         if observation_types := filters.get("observation_types"):

--- a/src/memory/api/search/embeddings.py
+++ b/src/memory/api/search/embeddings.py
@@ -10,7 +10,19 @@ from memory.common.collections import (
     MULTIMODAL_COLLECTIONS,
     TEXT_COLLECTIONS,
 )
+from memory.api.search.filters import (
+    FILTER_REGISTRY,
+    SPECIAL_FILTER_KEYS,
+    build_registry_qdrant_filters,
+    reject_unknown_filter_keys,
+)
 from memory.api.search.types import SearchFilters
+
+# Qdrant accepts every logical filter key. Registry filters become payload
+# conditions; the special keys are hand-coded (access/person compound
+# conditions, source_id/confidence/observation payload shapes, and created_at
+# which has no Qdrant equivalent). Anything else is rejected loudly.
+QDRANT_ALLOWED_FILTER_KEYS = set(FILTER_REGISTRY) | SPECIAL_FILTER_KEYS
 
 if TYPE_CHECKING:
     from memory.common.access_control import AccessFilter
@@ -219,69 +231,38 @@ async def query_chunks(
     return results_by_collection
 
 
-def merge_range_filter(
-    filters: list[dict[str, Any]], key: str, val: Any
-) -> list[dict[str, Any]]:
-    direction, field = key.split("_", maxsplit=1)
-    item = next((f for f in filters if f["key"] == field), None)
-    if not item:
-        item = {"key": field, "range": {}}
-        filters.append(item)
+def build_qdrant_special_filters(filters: "SearchFilters") -> list[dict[str, Any]]:
+    """Qdrant filters for keys hand-coded outside the shared registry.
 
-    if direction == "min":
-        item["range"]["gte"] = val
-    elif direction == "max":
-        item["range"]["lte"] = val
-    return filters
+    Covers the Qdrant-specific payload shapes:
+      - source_ids -> payload key "source_id" (singular) match.any
+      - min_confidences -> "confidence.{type}" range
+      - observation_types -> "observation_types" match.any
 
+    access_filter and person_id are NOT handled here — they build compound
+    conditions in :func:`search_chunks`.
 
-def merge_filters(
-    filters: list[dict[str, Any]], key: str, val: Any
-) -> list[dict[str, Any]]:
-    if not val and val != 0:
-        return filters
-
-    list_filters = ["tags", "recipients", "observation_types", "authors"]
-    range_filters = [
-        "min_sent_at",
-        "max_sent_at",
-        "min_published",
-        "max_published",
-        "min_size",
-        "max_size",
-        "min_created_at",
-        "max_created_at",
-    ]
-    # String match filters - exact match on metadata fields
-    string_filters = ["folder_path", "sender", "domain", "author"]
-
-    if key in list_filters:
-        filters.append({"key": key, "match": {"any": val}})
-
-    elif key in range_filters:
-        return merge_range_filter(filters, key, val)
-
-    elif key in string_filters:
-        filters.append({"key": key, "match": {"value": val}})
-
-    elif key == "min_confidences":
-        confidence_filters = [
-            {
-                "key": f"confidence.{confidence_type}",
-                "range": {"gte": min_confidence_score},
-            }
-            for confidence_type, min_confidence_score in cast(dict, val).items()
-        ]
-        filters.extend(confidence_filters)
-
-    elif key == "source_ids":
-        filters.append({"key": "source_id", "match": {"any": val}})
-
-    else:
-        # Log and ignore unknown filter keys to prevent injection
-        logger.warning(f"Unknown filter key ignored: {key}")
-
-    return filters
+    min/max_created_at are deliberately NOT emitted as Qdrant conditions: the
+    chunk payload (``item_metadata``, built from ``SourceItem.as_payload()``)
+    carries no created_at/inserted_at key, so a range on it would match zero
+    points and silently drop every vector hit on a dated search. The bound is
+    honored on the BM25/SQL arm (``Chunk.created_at``) instead, so created_at
+    stays in ``QDRANT_ALLOWED_FILTER_KEYS`` rather than raising. Known
+    limitation: because the two arms are RRF-fused, a vector hit outside the
+    range can still surface via the embedding arm; closing that needs a
+    created_at payload field + reindex (out of scope here).
+    """
+    result: list[dict[str, Any]] = []
+    if source_ids := filters.get("source_ids"):
+        result.append({"key": "source_id", "match": {"any": source_ids}})
+    if observation_types := filters.get("observation_types"):
+        result.append({"key": "observation_types", "match": {"any": observation_types}})
+    if min_confidences := filters.get("min_confidences"):
+        result.extend(
+            {"key": f"confidence.{ctype}", "range": {"gte": score}}
+            for ctype, score in cast(dict, min_confidences).items()
+        )
+    return result
 
 
 def require_access_filter(filters: "SearchFilters | None", caller: str) -> "SearchFilters":
@@ -343,14 +324,16 @@ async def search_chunks(
             ``access_filter`` cannot silently widen results).
     """
     filters = require_access_filter(filters, "search_chunks")
+    reject_unknown_filter_keys(filters, allowed=QDRANT_ALLOWED_FILTER_KEYS)
     if modalities is None:
         modalities = set()
-    search_filters: list[dict[str, Any]] = []
-    for key, val in filters.items():
-        if key in ("access_filter", "person_id"):
-            # Handle these filters separately (they create compound conditions)
-            continue
-        search_filters = merge_filters(search_filters, key, val)
+
+    # Registry filters (raises if an UNSUPPORTED filter like subject is passed,
+    # so it fails loudly instead of leaking unfiltered results) plus the
+    # Qdrant-specific special-key shapes. access_filter and person_id build
+    # compound conditions below.
+    search_filters = build_registry_qdrant_filters(filters)
+    search_filters.extend(build_qdrant_special_filters(filters))
 
     # Build the complete Qdrant filter
     qdrant_filter: dict[str, Any] = {}

--- a/src/memory/api/search/filters.py
+++ b/src/memory/api/search/filters.py
@@ -1,0 +1,375 @@
+"""Single source of truth for translating logical search filters.
+
+The same logical filters (``MCPSearchFilters``) need to be turned into three
+different backend queries:
+
+1. list/count SQL over ``SourceItem`` (``apply_item_filters`` in core.py)
+2. BM25 SQL over ``Chunk`` joined to ``SourceItem`` (``search_bm25`` in bm25.py)
+3. Qdrant payload filters (``search_chunks`` in embeddings.py)
+
+Historically each backend hand-maintained its own mapping, and they drifted:
+a filter implemented in one arm but skipped in another silently produced
+confidently-wrong results (e.g. ``recipients`` honored by Qdrant but ignored
+by BM25, so non-matching mail leaked into the RRF-merged output).
+
+This module declares each content-metadata filter once as a :class:`FilterSpec`
+and exposes thin translators that fold the registry onto a SQLAlchemy query or
+into Qdrant filter dicts. A completeness invariant (asserted at import and
+covered by a pure-Python test) forces every new ``MCPSearchFilters`` key to be
+wired here or explicitly marked special.
+
+Filters that are genuinely backend-specific and hand-coded (access control,
+person association, source-id prefiltering, confidence scores, observation
+collection routing, and the created_at divergence described below) live in
+:data:`SPECIAL_FILTER_KEYS` rather than the registry.
+"""
+
+from dataclasses import dataclass
+from enum import Enum
+from typing import Any
+
+from sqlalchemy import cast as sql_cast
+from sqlalchemy.dialects.postgresql import ARRAY
+from sqlalchemy import Text
+
+from memory.common.db.models import BlogPost, GoogleDoc, MailMessage, SourceItem
+from memory.api.search.types import MCPSearchFilters, SearchFilters
+
+
+class SqlOp(Enum):
+    """How a filter value constrains a SQL column."""
+
+    EQ = "eq"
+    GTE = "gte"
+    LTE = "lte"
+    IN = "in"
+    ARRAY_ANY = "array_any"  # Postgres ``&&`` overlap on an ARRAY column
+    ILIKE_SUBSTR = "ilike_substr"  # case-insensitive substring match
+
+
+class QdrantOp(Enum):
+    """How a filter value constrains a Qdrant payload field."""
+
+    MATCH_VALUE = "match_value"  # exact scalar match
+    MATCH_ANY = "match_any"  # list membership (match.any)
+    RANGE_GTE = "range_gte"
+    RANGE_LTE = "range_lte"
+
+
+# Sentinel meaning "this filter has no faithful Qdrant equivalent". A Qdrant
+# translator that is handed such a filter must raise rather than silently drop
+# it or emit a filter with different semantics.
+class QdrantUnsupported:
+    """No faithful Qdrant translation exists for this filter.
+
+    ``subject`` is matched in SQL with a case-insensitive substring (ILIKE).
+    Qdrant only offers exact ``match.value`` (the payload has no full-text
+    index on ``subject``), so a Qdrant ``subject`` filter would silently
+    change the semantics from substring to exact. Rather than lie, a Qdrant
+    caller that passes ``subject`` gets a loud ``ValueError``.
+    """
+
+    __slots__ = ()
+
+    def __repr__(self) -> str:
+        return "QDRANT_UNSUPPORTED"
+
+
+QDRANT_UNSUPPORTED = QdrantUnsupported()
+
+
+@dataclass(frozen=True)
+class FilterSpec:
+    """Declarative description of one logical filter across all backends.
+
+    Attributes:
+        key: The ``MCPSearchFilters`` TypedDict key.
+        model: Target ORM model. ``None`` means the column lives on
+            ``SourceItem`` itself; otherwise the model is a joined-table
+            subclass joined on ``model.id == SourceItem.id``.
+        column: Attribute name of the column on ``model`` (or ``SourceItem``).
+        sql_op: How the value constrains that column in SQL.
+        qdrant_key: Payload key in Qdrant, or ``None`` when unsupported.
+        qdrant_op: Qdrant operator, or :data:`QDRANT_UNSUPPORTED`.
+        array_cast: When ``True`` the bound value is cast to ``ARRAY(Text)``
+            before the SQL comparison (matches the ARRAY(Text) columns).
+    """
+
+    key: str
+    model: type | None
+    column: str
+    sql_op: SqlOp
+    qdrant_key: str | None
+    qdrant_op: QdrantOp | QdrantUnsupported
+    array_cast: bool = False
+
+    def target_model(self) -> type:
+        return self.model or SourceItem
+
+    def column_attr(self):
+        return getattr(self.target_model(), self.column)
+
+
+# Content-metadata filters. Each min/max pair is two specs on the same column.
+#
+# Qdrant payload keys are whatever ``as_payload()`` emits per subclass
+# (merged into ``Chunk.item_metadata`` at ingestion). Notably:
+#   - MailMessage emits the sent date under "date" (NOT "sent_at"), and
+#     emits "folder" (NOT "folder_path").
+#   - "subject" exists in the mail payload but only supports exact match in
+#     Qdrant, so it is marked QDRANT_UNSUPPORTED (see QdrantUnsupported).
+#
+# WARNING: of these payload keys, only "tags" (and "people", used elsewhere)
+# have a Qdrant payload index (see qdrant.create_payload_index). Filtering an
+# unindexed payload key may silently match nothing in Qdrant. Adding the
+# indexes is a separate follow-up (a migration / reindex), deliberately out of
+# scope here.
+_SPECS: tuple[FilterSpec, ...] = (
+    FilterSpec("tags", None, "tags", SqlOp.ARRAY_ANY, "tags", QdrantOp.MATCH_ANY, array_cast=True),
+    FilterSpec("min_size", None, "size", SqlOp.GTE, "size", QdrantOp.RANGE_GTE),
+    FilterSpec("max_size", None, "size", SqlOp.LTE, "size", QdrantOp.RANGE_LTE),
+    # Mail
+    FilterSpec("sender", MailMessage, "sender", SqlOp.EQ, "sender", QdrantOp.MATCH_VALUE),
+    FilterSpec(
+        "recipients", MailMessage, "recipients", SqlOp.ARRAY_ANY,
+        "recipients", QdrantOp.MATCH_ANY, array_cast=True,
+    ),
+    FilterSpec("subject", MailMessage, "subject", SqlOp.ILIKE_SUBSTR, None, QDRANT_UNSUPPORTED),
+    FilterSpec("min_sent_at", MailMessage, "sent_at", SqlOp.GTE, "date", QdrantOp.RANGE_GTE),
+    FilterSpec("max_sent_at", MailMessage, "sent_at", SqlOp.LTE, "date", QdrantOp.RANGE_LTE),
+    # Google Docs
+    FilterSpec(
+        "folder_path", GoogleDoc, "folder_path", SqlOp.ILIKE_SUBSTR,
+        "folder_path", QdrantOp.MATCH_VALUE,
+    ),
+    # Blog
+    FilterSpec("domain", BlogPost, "domain", SqlOp.EQ, "domain", QdrantOp.MATCH_VALUE),
+    FilterSpec("author", BlogPost, "author", SqlOp.EQ, "author", QdrantOp.MATCH_VALUE),
+    FilterSpec("authors", BlogPost, "author", SqlOp.IN, "authors", QdrantOp.MATCH_ANY),
+    FilterSpec("min_published", BlogPost, "published", SqlOp.GTE, "published", QdrantOp.RANGE_GTE),
+    FilterSpec("max_published", BlogPost, "published", SqlOp.LTE, "published", QdrantOp.RANGE_LTE),
+)
+
+FILTER_REGISTRY: dict[str, FilterSpec] = {spec.key: spec for spec in _SPECS}
+
+
+# Keys deliberately NOT in the registry because they are backend-specific and
+# hand-coded in each consumer.
+#
+# created_at is special because the two SQL backends scope it to *different*
+# columns on purpose:
+#   - list/count filter SourceItem.inserted_at (when the item entered the KB)
+#   - bm25 filters Chunk.created_at (when the chunk was created)
+#   - Qdrant has no per-chunk created_at payload key at all.
+# These are not interchangeable (a chunk can be re-derived after the item was
+# first inserted), so they are intentionally NOT unified into one registry
+# spec. If a future change makes them provably identical, fold them in.
+SPECIAL_FILTER_KEYS: frozenset[str] = frozenset(
+    {
+        "access_filter",
+        "person_id",
+        "source_ids",
+        "min_confidences",
+        "observation_types",
+        "min_created_at",
+        "max_created_at",
+    }
+)
+
+
+def mcp_filter_keys() -> set[str]:
+    return set(MCPSearchFilters.__annotations__)
+
+
+def search_only_keys() -> set[str]:
+    """SearchFilters keys NOT in MCPSearchFilters (internal-only).
+
+    ``SearchFilters`` is a ``TypedDict`` subclass; in Python 3.12 its
+    ``__annotations__`` carries both its own and the inherited keys.
+    Subtracting the MCP keys yields exactly the internal additions
+    (``source_ids``/``access_filter``).
+    """
+    return set(SearchFilters.__annotations__) - mcp_filter_keys()
+
+
+def check_registry_completeness() -> None:
+    """Raise if the registry has drifted from the filter TypedDicts.
+
+    Every MCP filter key must be either in :data:`FILTER_REGISTRY` or in
+    :data:`SPECIAL_FILTER_KEYS` (and not both). Every ``SearchFilters``-only
+    key (``source_ids``/``access_filter``) must be special. This is the
+    anti-drift guarantee: adding a TypedDict key without wiring it everywhere
+    fails here.
+    """
+    mcp_keys = mcp_filter_keys()
+    search_only = search_only_keys()
+    all_keys = mcp_keys | search_only
+    registry_keys = set(FILTER_REGISTRY)
+    overlap = registry_keys & SPECIAL_FILTER_KEYS
+    if overlap:
+        raise ValueError(f"keys both in registry and special: {sorted(overlap)}")
+
+    # The covered universe is every SearchFilters key (MCP keys plus the
+    # internal-only ``source_ids``/``access_filter``). A registry/special key
+    # not present anywhere in SearchFilters signals a typo or removed field.
+    covered = registry_keys | SPECIAL_FILTER_KEYS
+    missing = mcp_keys - covered
+    extra = covered - all_keys
+    if missing:
+        raise ValueError(
+            f"MCPSearchFilters keys not wired in registry or SPECIAL_FILTER_KEYS: "
+            f"{sorted(missing)}"
+        )
+    if extra:
+        raise ValueError(
+            f"registry/special keys not present in SearchFilters: {sorted(extra)}"
+        )
+
+    not_special = search_only - SPECIAL_FILTER_KEYS
+    if not_special:
+        raise ValueError(
+            f"SearchFilters-only keys must be in SPECIAL_FILTER_KEYS: "
+            f"{sorted(not_special)}"
+        )
+
+
+# Fail fast at import if anyone edits MCPSearchFilters without wiring it.
+check_registry_completeness()
+
+
+def escape_like(s: str) -> str:
+    """Escape ILIKE metacharacters to prevent pattern injection."""
+    return s.replace("\\", "\\\\").replace("%", "\\%").replace("_", "\\_")
+
+
+def apply_spec_sql(query, spec: FilterSpec, value: Any, *, joined: set[type]):
+    """Fold one registry spec onto a SQLAlchemy query.
+
+    ``joined`` tracks subclass models already joined to ``SourceItem`` so each
+    is joined at most once (joins are 1:1 on ``id``, so they never multiply
+    rows). Returns the updated query.
+    """
+    model = spec.model
+    if model is not None and model not in joined:
+        # Join the raw subclass table (not the polymorphic entity) so the
+        # ON clause binds to the outer SourceItem row. Joining the entity
+        # re-aliases source_item and yields a cartesian product.
+        table = model.__table__
+        query = query.join(table, table.c.id == SourceItem.id)
+        joined.add(model)
+
+    column = spec.column_attr()
+
+    if spec.sql_op is SqlOp.EQ:
+        return query.filter(column == value)
+    if spec.sql_op is SqlOp.GTE:
+        return query.filter(column >= value)
+    if spec.sql_op is SqlOp.LTE:
+        return query.filter(column <= value)
+    if spec.sql_op is SqlOp.IN:
+        return query.filter(column.in_(value))
+    if spec.sql_op is SqlOp.ARRAY_ANY:
+        # The Postgres `&&` overlap needs an array on both sides. A scalar here
+        # (e.g. tags="foo" instead of ["foo"]) would cast to a malformed array
+        # and fail at execution; reject it loudly at build time instead.
+        if not isinstance(value, (list, tuple)):
+            raise ValueError(
+                f"filter {spec.key!r} expects a list value, got {type(value).__name__}"
+            )
+        bound = sql_cast(value, ARRAY(Text)) if spec.array_cast else value
+        return query.filter(column.op("&&")(bound))
+    if spec.sql_op is SqlOp.ILIKE_SUBSTR:
+        return query.filter(column.ilike(f"%{escape_like(value)}%", escape="\\"))
+    raise ValueError(f"unhandled SQL op {spec.sql_op}")  # pragma: no cover
+
+
+def is_empty_value(value: Any) -> bool:
+    """A filter value that should be treated as 'not provided'.
+
+    Matches the falsy-but-keep-zero convention used by the legacy mappers:
+    ``None``/``[]``/``{}``/``""`` are skipped, but ``0`` is a real bound.
+    """
+    return value is None or value == [] or value == {} or value == ""
+
+
+def apply_registry_filters_sql(query, filters, *, joined: set[type] | None = None):
+    """Fold all registry filters present in ``filters`` onto a SQL query.
+
+    Used by both list/count (query over ``SourceItem``) and BM25 (query over
+    ``Chunk`` already joined to ``SourceItem``); the same ``model.id ==
+    SourceItem.id`` join works in both because the join is 1:1.
+
+    Combining filters from two different subclasses can never match a row (an
+    item is exactly one subclass) — that is the correct outcome, not a bug.
+
+    Pass ``joined`` to share join-tracking with a caller that has already
+    joined some subclass tables. Returns the updated query.
+    """
+    if joined is None:
+        joined = set()
+    for key, spec in FILTER_REGISTRY.items():
+        value = filters.get(key)
+        if is_empty_value(value):
+            continue
+        query = apply_spec_sql(query, spec, value, joined=joined)
+    return query
+
+
+def merge_range(filters: list[dict[str, Any]], key: str, op: QdrantOp, value: Any) -> None:
+    """Add or extend a Qdrant range filter on payload ``key`` in place."""
+    item = next((f for f in filters if f.get("key") == key and "range" in f), None)
+    if item is None:
+        item = {"key": key, "range": {}}
+        filters.append(item)
+    if op is QdrantOp.RANGE_GTE:
+        item["range"]["gte"] = value
+    elif op is QdrantOp.RANGE_LTE:
+        item["range"]["lte"] = value
+
+
+def build_registry_qdrant_filters(filters) -> list[dict[str, Any]]:
+    """Translate registry filters present in ``filters`` into Qdrant dicts.
+
+    Raises ``ValueError`` if a filter whose Qdrant translation is
+    :data:`QDRANT_UNSUPPORTED` (e.g. ``subject``) was provided, so an
+    unsupported Qdrant filter fails loudly instead of leaking unfiltered
+    results.
+    """
+    result: list[dict[str, Any]] = []
+    for key, spec in FILTER_REGISTRY.items():
+        value = filters.get(key)
+        if is_empty_value(value):
+            continue
+        if isinstance(spec.qdrant_op, QdrantUnsupported):
+            raise ValueError(
+                f"filter {key!r} has no faithful Qdrant translation "
+                f"(SQL uses {spec.sql_op.value}); it cannot be applied to a "
+                "vector search"
+            )
+        qkey = spec.qdrant_key
+        # Past the QDRANT_UNSUPPORTED guard above, every remaining spec pairs a
+        # concrete payload key with its qdrant_op; the registry never leaves
+        # qdrant_key None alongside a usable op.
+        assert qkey is not None
+        if spec.qdrant_op is QdrantOp.MATCH_VALUE:
+            result.append({"key": qkey, "match": {"value": value}})
+        elif spec.qdrant_op is QdrantOp.MATCH_ANY:
+            result.append({"key": qkey, "match": {"any": value}})
+        elif spec.qdrant_op in (QdrantOp.RANGE_GTE, QdrantOp.RANGE_LTE):
+            merge_range(result, qkey, spec.qdrant_op, value)
+    return result
+
+
+def reject_unknown_filter_keys(filters, *, allowed: set[str]) -> None:
+    """Raise ``ValueError`` on any non-empty filter key outside ``allowed``.
+
+    One consistent loud failure for all three backends, replacing core's
+    ad-hoc ValueError, Qdrant's warn-and-ignore, and BM25's silent skip. A
+    filter a backend forgot to implement becomes an error instead of a
+    confidently-wrong result.
+    """
+    leftover = {
+        k for k, v in filters.items() if not is_empty_value(v) and k not in allowed
+    }
+    if leftover:
+        raise ValueError(f"Unsupported filter(s): {sorted(leftover)}")

--- a/tests/memory/api/MCP/test_core_tools.py
+++ b/tests/memory/api/MCP/test_core_tools.py
@@ -21,7 +21,6 @@ from memory.api.MCP.servers.core import (
     filter_source_ids,
 )
 from memory.api.search.types import SearchFilters
-from memory.common import extract
 from memory.common.db.models.source_item import SourceItem
 from tests.conftest import mcp_auth_context
 

--- a/tests/memory/api/MCP/test_core_tools.py
+++ b/tests/memory/api/MCP/test_core_tools.py
@@ -1840,3 +1840,103 @@ async def test_search_skips_logging_when_no_user(
 
     await search.fn(query="anonymous")
     mock_log_search.assert_not_called()
+
+
+# ====== apply_item_filters + list/count parity (real DB) ======
+
+
+def make_mail(sha: bytes, *, sender, recipients, subject, sent_at, content="body"):
+    """Build a STORED MailMessage row for enumeration tests."""
+    from memory.common.db.models import MailMessage
+
+    return MailMessage(
+        sha256=sha,
+        content=content,
+        size=len(content),
+        mime_type="message/rfc822",
+        modality="mail",
+        embed_status="STORED",
+        tags=[],
+        sender=sender,
+        recipients=recipients,
+        subject=subject,
+        sent_at=sent_at,
+        folder="INBOX",
+    )
+
+
+def seed_mail(db_session):
+    """Two mail messages differing on sender/recipients/subject/sent_at."""
+    a = make_mail(
+        b"mail-a",
+        sender="alice@example.com",
+        recipients=["bob@example.com"],
+        subject="Quarterly report",
+        sent_at=datetime(2020, 1, 1, tzinfo=timezone.utc),
+    )
+    b = make_mail(
+        b"mail-b",
+        sender="carol@example.com",
+        recipients=["dave@example.com"],
+        subject="Lunch plans",
+        sent_at=datetime(2023, 6, 1, tzinfo=timezone.utc),
+    )
+    db_session.add_all([a, b])
+    db_session.commit()
+    return a, b
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "filters",
+    [
+        {},
+        {"sender": "alice@example.com"},
+        {"recipients": ["bob@example.com"]},
+        {"subject": "report"},
+        {"min_sent_at": "2022-01-01T00:00:00+00:00"},
+    ],
+)
+async def test_list_and_count_agree_on_total(db_session, admin_session, filters):
+    """list_items total and count_items total never diverge for the same filters."""
+    seed_mail(db_session)
+    with mcp_auth_context(admin_session.id):
+        listed = await list_items.fn(modalities={"mail"}, filters=filters)
+        counted = await count_items.fn(modalities={"mail"}, filters=filters)
+    assert listed["total"] == counted["total"]
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "filters, expected_subjects",
+    [
+        ({"sender": "alice@example.com"}, {"Quarterly report"}),
+        ({"recipients": ["bob@example.com"]}, {"Quarterly report"}),
+        ({"recipients": ["dave@example.com"]}, {"Lunch plans"}),
+        ({"subject": "lunch"}, {"Lunch plans"}),
+        ({"min_sent_at": "2022-01-01T00:00:00+00:00"}, {"Lunch plans"}),
+        ({"max_sent_at": "2022-01-01T00:00:00+00:00"}, {"Quarterly report"}),
+    ],
+)
+async def test_mail_filters_discriminate_on_both_tools(
+    db_session, admin_session, filters, expected_subjects
+):
+    """recipients/subject/sent_at actually filter, identically, on list and count."""
+    seed_mail(db_session)
+    with mcp_auth_context(admin_session.id):
+        listed = await list_items.fn(modalities={"mail"}, filters=filters)
+        counted = await count_items.fn(modalities={"mail"}, filters=filters)
+
+    got_subjects = {item["metadata"]["subject"] for item in listed["items"]}
+    assert got_subjects == expected_subjects
+    assert listed["total"] == len(expected_subjects)
+    assert counted["total"] == len(expected_subjects)
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("tool", [list_items, count_items])
+async def test_unsupported_filter_raises_value_error(db_session, admin_session, tool):
+    """A filter key only meaningful for observation search is rejected, not ignored."""
+    with mcp_auth_context(admin_session.id):
+        with pytest.raises(ValueError, match="Unsupported filter"):
+            await tool.fn(filters={"observation_types": ["belief"]})

--- a/tests/memory/api/search/test_filters.py
+++ b/tests/memory/api/search/test_filters.py
@@ -1,0 +1,293 @@
+"""Tests for the unified search-filter registry (memory.api.search.filters).
+
+These tests are pure-Python where possible: the completeness invariant and the
+SQL/Qdrant translation assertions need neither a live DB nor a Qdrant engine
+(SQL is checked via compiled-statement strings). The "unknown key raises at all
+three entry points" tests touch the three backends' rejection wiring; the
+rejection fires before any DB session or Qdrant client opens, so they need no
+live infrastructure either.
+"""
+
+import asyncio
+
+import pytest
+from sqlalchemy.dialects import postgresql
+from sqlalchemy.orm import Query
+
+from memory.api.search import filters as F
+from memory.api.search.bm25 import search_bm25
+from memory.api.search.embeddings import search_chunks
+from memory.api.search.types import MCPSearchFilters, SearchFilters
+from memory.api.MCP.servers.core import apply_item_filters
+from memory.common.db.models import Chunk, SourceItem
+from memory.common.extract import DataChunk
+
+
+def compile_sql(query) -> str:
+    return str(
+        query.statement.compile(
+            dialect=postgresql.dialect(),
+            compile_kwargs={"literal_binds": True},
+        )
+    )
+
+
+def registry_query(filters: dict):
+    return F.apply_registry_filters_sql(Query(SourceItem), filters)
+
+
+# --- (a) completeness invariant ---------------------------------------------
+
+
+def test_registry_completeness_holds():
+    F.check_registry_completeness()
+
+
+def test_every_mcp_key_is_registry_or_special():
+    mcp_keys = set(MCPSearchFilters.__annotations__)
+    assert mcp_keys == set(F.FILTER_REGISTRY) | (
+        F.SPECIAL_FILTER_KEYS & mcp_keys
+    )
+
+
+def test_registry_and_special_are_disjoint():
+    assert not (set(F.FILTER_REGISTRY) & F.SPECIAL_FILTER_KEYS)
+
+
+def test_search_only_keys_are_special():
+    search_only = set(SearchFilters.__annotations__) - set(
+        MCPSearchFilters.__annotations__
+    )
+    assert search_only == {"source_ids", "access_filter"}
+    assert search_only <= F.SPECIAL_FILTER_KEYS
+
+
+def test_completeness_detects_unwired_key(monkeypatch):
+    original = F.mcp_filter_keys()
+    monkeypatch.setattr(
+        F, "mcp_filter_keys", lambda: original | {"brand_new_filter"}
+    )
+    with pytest.raises(ValueError, match="not wired"):
+        F.check_registry_completeness()
+
+
+def test_completeness_detects_registry_special_overlap(monkeypatch):
+    monkeypatch.setattr(F, "SPECIAL_FILTER_KEYS", F.SPECIAL_FILTER_KEYS | {"tags"})
+    with pytest.raises(ValueError, match="both in registry and special"):
+        F.check_registry_completeness()
+
+
+# --- (b) each registry key produces expected SQL ----------------------------
+
+
+# Joined-table-inheritance subclasses are aliased by SQLAlchemy when SourceItem
+# is the primary entity (the subclass row already embeds source_item), so column
+# refs appear as ``mail_message_1.sender`` etc. The aliasing predates this
+# refactor (the original apply_item_filters joined the same way). We assert on a
+# column/op regex rather than a hard-coded table-alias name.
+
+
+@pytest.mark.parametrize(
+    "filters, table, column, op",
+    [
+        ({"sender": "a@b.com"}, "mail_message", "sender", "= 'a@b.com'"),
+        ({"min_sent_at": "2024-01-01"}, "mail_message", "sent_at", ">= '2024-01-01'"),
+        ({"max_sent_at": "2024-12-31"}, "mail_message", "sent_at", "<= '2024-12-31'"),
+        ({"domain": "example.com"}, "blog_post", "domain", "= 'example.com'"),
+        ({"author": "bob"}, "blog_post", "author", "= 'bob'"),
+        ({"min_published": "2020-01-01"}, "blog_post", "published", ">= '2020-01-01'"),
+        ({"max_published": "2020-12-31"}, "blog_post", "published", "<= '2020-12-31'"),
+    ],
+)
+def test_registry_sql_subclass_fragment(filters, table, column, op):
+    sql = compile_sql(registry_query(filters))
+    assert f".{column} {op}" in sql
+    assert table in sql
+
+
+@pytest.mark.parametrize(
+    "filters, fragment",
+    [
+        ({"min_size": 10}, "source_item.size >= 10"),
+        ({"max_size": 99}, "source_item.size <= 99"),
+    ],
+)
+def test_registry_sql_source_item_fragment(filters, fragment):
+    # size lives on SourceItem itself — no subclass join, no alias.
+    assert fragment in compile_sql(registry_query(filters))
+
+
+def test_registry_sql_subject_uses_ilike():
+    sql = compile_sql(registry_query({"subject": "hello"}))
+    assert ".subject ILIKE" in sql
+    assert "%hello%" in sql
+
+
+def test_registry_sql_folder_path_uses_ilike_on_google_doc():
+    sql = compile_sql(registry_query({"folder_path": "Work"}))
+    assert ".folder_path ILIKE" in sql
+    assert "google_doc" in sql
+
+
+@pytest.mark.parametrize("array_key", ["tags", "recipients"])
+def test_registry_sql_array_overlap_cast_text(array_key):
+    sql = compile_sql(registry_query({array_key: ["x", "y"]}))
+    assert "&&" in sql
+    # Both tags and recipients are ARRAY(Text) columns, so the cast is TEXT[].
+    assert "AS TEXT[]" in sql
+
+
+def test_registry_sql_authors_uses_in():
+    sql = compile_sql(registry_query({"authors": ["a", "b"]}))
+    assert ".author IN" in sql
+    assert "blog_post" in sql
+
+
+def test_registry_sql_joins_each_subclass_once():
+    sql = compile_sql(
+        registry_query({"sender": "a", "subject": "b", "min_sent_at": "2024-01-01"})
+    )
+    # One join into the mail_message subclass even though three mail filters
+    # target it.
+    assert sql.count("JOIN mail_message") == 1
+
+
+def test_registry_sql_empty_values_skipped():
+    sql = compile_sql(registry_query({"sender": "", "tags": [], "recipients": None}))
+    assert "JOIN" not in sql
+    assert "WHERE" not in sql
+
+
+# --- (b') each registry key produces expected Qdrant filter -----------------
+
+
+@pytest.mark.parametrize(
+    "filters, expected",
+    [
+        ({"tags": ["x"]}, {"key": "tags", "match": {"any": ["x"]}}),
+        ({"recipients": ["a"]}, {"key": "recipients", "match": {"any": ["a"]}}),
+        ({"authors": ["a"]}, {"key": "authors", "match": {"any": ["a"]}}),
+        ({"sender": "s"}, {"key": "sender", "match": {"value": "s"}}),
+        ({"domain": "d"}, {"key": "domain", "match": {"value": "d"}}),
+        ({"author": "a"}, {"key": "author", "match": {"value": "a"}}),
+        ({"folder_path": "p"}, {"key": "folder_path", "match": {"value": "p"}}),
+        ({"min_size": 5}, {"key": "size", "range": {"gte": 5}}),
+        ({"max_size": 9}, {"key": "size", "range": {"lte": 9}}),
+    ],
+)
+def test_qdrant_single_filter(filters, expected):
+    assert F.build_registry_qdrant_filters(filters) == [expected]
+
+
+def test_qdrant_sent_at_maps_to_date_payload_key():
+    # Regression: the payload stores the email date under "date", not "sent_at".
+    result = F.build_registry_qdrant_filters(
+        {"min_sent_at": "2024-01-01", "max_sent_at": "2024-12-31"}
+    )
+    assert result == [
+        {"key": "date", "range": {"gte": "2024-01-01", "lte": "2024-12-31"}}
+    ]
+
+
+def test_qdrant_published_range_merges():
+    result = F.build_registry_qdrant_filters(
+        {"min_published": "2020-01-01", "max_published": "2020-12-31"}
+    )
+    assert result == [
+        {"key": "published", "range": {"gte": "2020-01-01", "lte": "2020-12-31"}}
+    ]
+
+
+# --- (c) UNSUPPORTED-over-Qdrant raises -------------------------------------
+
+
+def test_qdrant_subject_raises():
+    with pytest.raises(ValueError, match="no faithful Qdrant translation"):
+        F.build_registry_qdrant_filters({"subject": "anything"})
+
+
+def test_qdrant_subject_skipped_when_empty():
+    # An empty subject is "not provided" and must not raise.
+    assert F.build_registry_qdrant_filters({"subject": ""}) == []
+
+
+# --- (d) unknown key rejection ----------------------------------------------
+
+
+def test_reject_unknown_filter_keys_raises():
+    with pytest.raises(ValueError, match="Unsupported filter"):
+        F.reject_unknown_filter_keys(
+            {"bogus": "x"}, allowed=set(F.FILTER_REGISTRY)
+        )
+
+
+def test_reject_unknown_filter_keys_ignores_empty():
+    # Empty values for unknown keys are not "provided", so no error.
+    F.reject_unknown_filter_keys({"bogus": None, "other": []}, allowed=set())
+
+
+def test_reject_unknown_filter_keys_allows_known():
+    F.reject_unknown_filter_keys({"sender": "x"}, allowed=set(F.FILTER_REGISTRY))
+
+
+# --- (d') unknown key raises at all three backend entry points ---------------
+
+
+def test_core_entry_rejects_unknown_key():
+    with pytest.raises(ValueError, match="Unsupported filter"):
+        apply_item_filters(Query(SourceItem), set(), {"bogus": "x"})  # type: ignore[arg-type]
+
+
+def test_bm25_entry_rejects_unknown_key():
+    with pytest.raises(ValueError, match="Unsupported filter"):
+        asyncio.run(
+            search_bm25(
+                "hello",
+                {"mail"},
+                filters={"access_filter": None, "bogus": "x"},  # type: ignore[typeddict-unknown-key]
+            )
+        )
+
+
+def test_embeddings_entry_rejects_unknown_key():
+    with pytest.raises(ValueError, match="Unsupported filter"):
+        asyncio.run(
+            search_chunks(
+                [DataChunk(data=["q"])],
+                {"mail"},
+                filters={"access_filter": None, "bogus": "x"},  # type: ignore[typeddict-unknown-key]
+            )
+        )
+
+
+def test_embeddings_entry_rejects_subject_loudly():
+    # subject has no faithful Qdrant translation: it must fail, not leak.
+    with pytest.raises(ValueError, match="no faithful Qdrant translation"):
+        asyncio.run(
+            search_chunks(
+                [DataChunk(data=["q"])],
+                {"mail"},
+                filters={"access_filter": None, "subject": "hi"},
+            )
+        )
+
+
+def test_bm25_mail_filter_join_chain():
+    """Registry mail filters fold onto a bm25-style Chunk->SourceItem query.
+
+    bm25's base query is (Chunk.id, rank) joined to SourceItem; passing
+    joined={SourceItem} must suppress a duplicate SourceItem join and chain
+    MailMessage on SourceItem.id, yielding inner joins (no cartesian product).
+    """
+    base = Query(Chunk.id).join(SourceItem, SourceItem.id == Chunk.source_id)
+    q = F.apply_registry_filters_sql(
+        base, {"sender": "a@b.com", "recipients": ["x@y.com"]}, joined={SourceItem}
+    )
+    sql = compile_sql(q)
+    # SourceItem joined exactly once (pre-joined), MailMessage chained on its id
+    # via the raw table (joining the polymorphic entity would re-alias
+    # source_item and produce a cartesian product).
+    assert sql.count("JOIN source_item") == 1
+    assert "JOIN mail_message ON mail_message.id = source_item.id" in sql
+    assert "mail_message.sender = 'a@b.com'" in sql
+    assert "mail_message.recipients &&" in sql

--- a/tests/memory/api/search/test_search_embeddings.py
+++ b/tests/memory/api/search/test_search_embeddings.py
@@ -6,8 +6,7 @@ import copy
 import pickle
 
 from memory.api.search.embeddings import (
-    merge_range_filter,
-    merge_filters,
+    build_qdrant_special_filters,
     build_person_filter,
     build_access_qdrant_filter,
     NO_ACCESS,
@@ -16,67 +15,42 @@ from memory.api.search.embeddings import (
     search_chunks,
     search_chunks_embeddings,
 )
+from memory.api.search.filters import build_registry_qdrant_filters
 from memory.common.access_control import AccessFilter, AccessCondition
 from memory.common.extract import DataChunk
 
 
-def test_merge_range_filter_new_filter():
-    """Test adding new range filters"""
-    filters = []
-    result = merge_range_filter(filters, "min_size", 100)
-    assert result == [{"key": "size", "range": {"gte": 100}}]
-
-    filters = []
-    result = merge_range_filter(filters, "max_size", 1000)
-    assert result == [{"key": "size", "range": {"lte": 1000}}]
-
-
-def test_merge_range_filter_existing_field():
-    """Test adding to existing field"""
-    filters = [{"key": "size", "range": {"lte": 1000}}]
-    result = merge_range_filter(filters, "min_size", 100)
-    assert result == [{"key": "size", "range": {"lte": 1000, "gte": 100}}]
-
-
-def test_merge_range_filter_override_existing():
-    """Test overriding existing values"""
-    filters = [{"key": "size", "range": {"gte": 100}}]
-    result = merge_range_filter(filters, "min_size", 200)
-    assert result == [{"key": "size", "range": {"gte": 200}}]
-
-
-def test_merge_range_filter_with_other_filters():
-    """Test adding range filter alongside other filters"""
-    filters = [{"key": "tags", "match": {"any": ["tag1"]}}]
-    result = merge_range_filter(filters, "min_size", 100)
-
-    expected = [
-        {"key": "tags", "match": {"any": ["tag1"]}},
-        {"key": "size", "range": {"gte": 100}},
-    ]
-    assert result == expected
+# --- Qdrant filter translation (registry + special keys) ---
+#
+# The Qdrant filter dicts are now produced by the shared registry
+# (``build_registry_qdrant_filters``) plus the hand-coded special-key shapes
+# (``build_qdrant_special_filters``). These tests pin the translated output.
 
 
 @pytest.mark.parametrize(
-    "key,expected_direction,expected_field",
+    "key,value,expected_payload_key",
     [
-        ("min_sent_at", "min", "sent_at"),
-        ("max_sent_at", "max", "sent_at"),
-        ("min_published", "min", "published"),
-        ("max_published", "max", "published"),
-        ("min_size", "min", "size"),
-        ("max_size", "max", "size"),
+        ("min_size", 100, "size"),
+        ("max_size", 1000, "size"),
+        ("min_sent_at", "2024-01-01", "date"),  # payload stores email date as "date"
+        ("max_sent_at", "2024-12-31", "date"),
+        ("min_published", "2023-01-01", "published"),
+        ("max_published", "2023-12-31", "published"),
     ],
 )
-def test_merge_range_filter_key_parsing(key, expected_direction, expected_field):
-    """Test that field names are correctly extracted from keys"""
-    filters = []
-    result = merge_range_filter(filters, key, 100)
-
+def test_registry_range_filter_payload_key(key, value, expected_payload_key):
+    result = build_registry_qdrant_filters({key: value})
     assert len(result) == 1
-    assert result[0]["key"] == expected_field
-    range_key = "gte" if expected_direction == "min" else "lte"
-    assert result[0]["range"][range_key] == 100
+    assert result[0]["key"] == expected_payload_key
+    range_key = "gte" if key.startswith("min") else "lte"
+    assert result[0]["range"][range_key] == value
+
+
+def test_registry_combined_range_merges():
+    result = build_registry_qdrant_filters({"min_size": 100, "max_size": 1000})
+    size_filters = [f for f in result if f["key"] == "size"]
+    assert len(size_filters) == 1
+    assert size_filters[0]["range"] == {"gte": 100, "lte": 1000}
 
 
 @pytest.mark.parametrize(
@@ -84,37 +58,12 @@ def test_merge_range_filter_key_parsing(key, expected_direction, expected_field)
     [
         ("tags", ["tag1", "tag2"]),
         ("recipients", ["user1", "user2"]),
-        ("observation_types", ["belief", "preference"]),
         ("authors", ["author1"]),
     ],
 )
-def test_merge_filters_list_filters(filter_key, filter_value):
-    """Test list filters that use match any"""
-    filters = []
-    result = merge_filters(filters, filter_key, filter_value)
-    expected = [{"key": filter_key, "match": {"any": filter_value}}]
-    assert result == expected
-
-
-def test_merge_filters_min_confidences():
-    """Test min_confidences filter creates multiple range conditions"""
-    filters = []
-    confidences = {"observation_accuracy": 0.8, "source_reliability": 0.9}
-    result = merge_filters(filters, "min_confidences", confidences)
-
-    expected = [
-        {"key": "confidence.observation_accuracy", "range": {"gte": 0.8}},
-        {"key": "confidence.source_reliability", "range": {"gte": 0.9}},
-    ]
-    assert result == expected
-
-
-def test_merge_filters_source_ids():
-    """Test source_ids filter maps to source_id field in payload"""
-    filters = []
-    result = merge_filters(filters, "source_ids", ["id1", "id2"])
-    expected = [{"key": "source_id", "match": {"any": ["id1", "id2"]}}]
-    assert result == expected
+def test_registry_list_filters(filter_key, filter_value):
+    result = build_registry_qdrant_filters({filter_key: filter_value})
+    assert result == [{"key": filter_key, "match": {"any": filter_value}}]
 
 
 @pytest.mark.parametrize(
@@ -126,87 +75,60 @@ def test_merge_filters_source_ids():
         ("author", "John Doe"),
     ],
 )
-def test_merge_filters_string_filters(filter_key, filter_value):
-    """Test string filters create exact match conditions"""
-    filters = []
-    result = merge_filters(filters, filter_key, filter_value)
-    expected = [{"key": filter_key, "match": {"value": filter_value}}]
-    assert result == expected
+def test_registry_string_filters(filter_key, filter_value):
+    result = build_registry_qdrant_filters({filter_key: filter_value})
+    assert result == [{"key": filter_key, "match": {"value": filter_value}}]
 
 
-def test_merge_filters_range_delegation():
-    """Test range filters are properly delegated to merge_range_filter"""
-    filters = []
-    result = merge_filters(filters, "min_size", 100)
-
-    assert len(result) == 1
-    assert "range" in result[0]
-    assert result[0]["range"]["gte"] == 100
-
-
-def test_merge_filters_combined_range():
-    """Test that min/max range pairs merge into single filter"""
-    filters = []
-    filters = merge_filters(filters, "min_size", 100)
-    filters = merge_filters(filters, "max_size", 1000)
-
-    size_filters = [f for f in filters if f["key"] == "size"]
-    assert len(size_filters) == 1
-    assert size_filters[0]["range"]["gte"] == 100
-    assert size_filters[0]["range"]["lte"] == 1000
+def test_special_min_confidences():
+    confidences = {"observation_accuracy": 0.8, "source_reliability": 0.9}
+    result = build_qdrant_special_filters({"min_confidences": confidences})
+    assert result == [
+        {"key": "confidence.observation_accuracy", "range": {"gte": 0.8}},
+        {"key": "confidence.source_reliability", "range": {"gte": 0.9}},
+    ]
 
 
-def test_merge_filters_preserves_existing():
-    """Test that existing filters are preserved when adding new ones"""
-    existing_filters = [{"key": "existing", "match": "value"}]
-    result = merge_filters(existing_filters, "tags", ["new_tag"])
-
-    assert len(result) == 2
-    assert {"key": "existing", "match": "value"} in result
-    assert {"key": "tags", "match": {"any": ["new_tag"]}} in result
+def test_special_source_ids_maps_to_singular_payload_key():
+    result = build_qdrant_special_filters({"source_ids": [11, 22]})
+    assert result == [{"key": "source_id", "match": {"any": [11, 22]}}]
 
 
-def test_merge_filters_realistic_combination():
-    """Test a realistic filter combination for knowledge base search"""
-    filters = []
+def test_special_observation_types():
+    result = build_qdrant_special_filters({"observation_types": ["belief", "preference"]})
+    assert result == [
+        {"key": "observation_types", "match": {"any": ["belief", "preference"]}}
+    ]
 
-    # Add typical knowledge base filters
-    filters = merge_filters(filters, "tags", ["important", "work"])
-    filters = merge_filters(filters, "min_published", "2023-01-01")
-    filters = merge_filters(filters, "max_size", 1000000)  # 1MB max
-    filters = merge_filters(filters, "min_confidences", {"observation_accuracy": 0.8})
 
-    assert len(filters) == 4
+def test_registry_empty_min_confidences_is_special_not_registry():
+    # min_confidences is a special key; the registry never emits it.
+    assert build_registry_qdrant_filters({"min_confidences": {}}) == []
+    assert build_qdrant_special_filters({"min_confidences": {}}) == []
 
-    # Check each filter type
-    tag_filter = next(f for f in filters if f["key"] == "tags")
+
+def test_registry_realistic_combination():
+    filters = {
+        "tags": ["important", "work"],
+        "min_published": "2023-01-01",
+        "max_size": 1000000,
+    }
+    result = build_registry_qdrant_filters(filters)
+    result += build_qdrant_special_filters({"min_confidences": {"observation_accuracy": 0.8}})
+
+    tag_filter = next(f for f in result if f["key"] == "tags")
     assert tag_filter["match"]["any"] == ["important", "work"]
 
-    published_filter = next(f for f in filters if f["key"] == "published")
+    published_filter = next(f for f in result if f["key"] == "published")
     assert published_filter["range"]["gte"] == "2023-01-01"
 
-    size_filter = next(f for f in filters if f["key"] == "size")
+    size_filter = next(f for f in result if f["key"] == "size")
     assert size_filter["range"]["lte"] == 1000000
 
     confidence_filter = next(
-        f for f in filters if f["key"] == "confidence.observation_accuracy"
+        f for f in result if f["key"] == "confidence.observation_accuracy"
     )
     assert confidence_filter["range"]["gte"] == 0.8
-
-
-def test_merge_filters_unknown_key():
-    """Test that unknown filter keys are logged and ignored for security"""
-    filters = []
-    result = merge_filters(filters, "unknown_field", "unknown_value")
-    # Unknown keys should be ignored to prevent filter injection
-    assert result == []
-
-
-def test_merge_filters_empty_min_confidences():
-    """Test min_confidences with empty dict does nothing"""
-    filters = []
-    result = merge_filters(filters, "min_confidences", {})
-    assert result == []
 
 
 # --- Person Filter Tests ---
@@ -252,13 +174,12 @@ def test_build_person_filter_different_ids(person_id):
     assert match_condition["match"]["any"] == [person_id]
 
 
-def test_merge_filters_ignores_person_id():
-    """Test that merge_filters ignores person_id key (handled separately)"""
-    filters = []
-    result = merge_filters(filters, "person_id", 42)
-    # person_id is handled separately in search_chunks, so merge_filters should ignore it
-    # (it falls through to the unknown key case)
-    assert result == []
+def test_person_id_not_emitted_by_filter_builders():
+    """person_id is a special key: neither the registry nor the special-key
+    builder emits a payload condition for it (search_chunks builds the
+    compound person filter separately)."""
+    assert build_registry_qdrant_filters({"person_id": 42}) == []
+    assert build_qdrant_special_filters({"person_id": 42}) == []
 
 
 # --- Access Control Filter Tests ---

--- a/tests/memory/api/test_ingest_endpoint.py
+++ b/tests/memory/api/test_ingest_endpoint.py
@@ -1,6 +1,7 @@
 """Tests for the /ingest/upload endpoint and land_and_dispatch helper."""
 
 import pathlib
+from typing import Any
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -12,7 +13,7 @@ from memory.common import settings
 
 
 def _intent(**kw):
-    base = dict(
+    base: dict[str, Any] = dict(
         user_id=42, type="application/pdf", filename="f", tags=["t"],
         doc_metadata={"title": "Tt", "author": "Aa", "k": "v"},
         project_id=9, exp=None,

--- a/tests/memory/api/test_transfer_tokens.py
+++ b/tests/memory/api/test_transfer_tokens.py
@@ -304,7 +304,6 @@ def _mint_with_raw_payload(raw_data: dict) -> str:
     Used to forge tokens with wrong types — exercises the verify-side
     type coercion that protects against future code paths writing junk.
     """
-    import base64
     import json as _json
 
     from memory.api import signed_tokens

--- a/tests/memory/common/db/test_misc_doc.py
+++ b/tests/memory/common/db/test_misc_doc.py
@@ -33,7 +33,9 @@ def test_misc_doc_chunks_text_file(db_session):
     chunks = doc._chunk_contents()
     assert chunks  # non-empty
 
-    payload = doc.as_payload()
+    # dict view: as_payload() merges arbitrary doc_metadata keys that the
+    # MiscDocPayload TypedDict cannot statically declare.
+    payload = dict(doc.as_payload())
     assert payload["source"] == "unit-test"
     assert payload["pages"] == 1
     assert payload["content_type"] == "text/plain"
@@ -59,7 +61,7 @@ def test_misc_doc_as_payload_metadata_collision(db_session):
     db_session.flush()
 
     # Must not raise despite metadata keys colliding with typed/base fields.
-    payload = doc.as_payload()
+    payload = dict(doc.as_payload())
     assert payload["filename"] == filename
     assert payload["tags"] == ["t"]
     assert payload["source"] == "x"

--- a/tests/memory/common/test_extract.py
+++ b/tests/memory/common/test_extract.py
@@ -1,3 +1,6 @@
+# pyright: reportAttributeAccessIssue=false
+# PyMuPDF's `pymupdf.open` (== Document) ships incomplete stubs that omit
+# Document.new_page; the methods exist at runtime.
 import pathlib
 import pytest
 import pymupdf


### PR DESCRIPTION
## Summary

The same `MCPSearchFilters` were translated to backend queries in three hand-maintained places — list/count SQL (`apply_item_filters`), BM25 SQL (`search_bm25`), and Qdrant payload (`search_chunks`) — that had silently drifted. A filter implemented in one arm but skipped in another produced confidently-wrong results (e.g. `recipients` honored by Qdrant but ignored by BM25, leaking non-matching mail through the RRF merge; `count_items` and `list_items` disagreeing on totals for the same filter set).

This introduces `src/memory/api/search/filters.py` as the single source of truth and rewires all three backends to consume it. Drift is now structurally prevented:
- `FILTER_REGISTRY` — declarative `FilterSpec`s (key → model.column, SQL op, Qdrant op).
- `SPECIAL_FILTER_KEYS` — backend-specific hand-coded filters (access/person/source_ids/confidence/observation/created_at).
- `reject_unknown_filter_keys` — one loud failure replacing the three backends' ad-hoc ValueError / warn-and-ignore / silent-skip behaviours.
- `check_registry_completeness()` — asserted at import **and** unit-tested, so adding an `MCPSearchFilters` key forces wiring it everywhere or the build fails.

## Bugs fixed while building it
- **Cartesian product**: JTI subclass joins used the polymorphic ORM entity, which re-aliased `source_item`. Now join `model.__table__` on `SourceItem.id`.
- **BM25 cross-join / access bypass**: `needs_source_join` used truthiness, so `min_size=0` skipped the SourceItem join while the registry still emitted `size >= 0` → uncorrelated cross join that also escaped the access filter. Now gated on `is_empty_value`.
- **Silent drops**: `subject`/`recipients`/`sent_at` were ignored on the SQL arms; now applied. `subject` over Qdrant raises (no faithful equivalent) rather than leaking.
- **observation_types/min_confidences** now rejected by list/count (observation-search-only).

## Known limitation
`created_at` is accepted but applied only on the SQL arm — the Qdrant chunk payload carries no created_at key, so a range there would match nothing. Documented inline; closing it needs a payload field + reindex (out of scope).

## Tests
221 passed / 28 skipped across the four affected test files; pyright clean (0 errors) on all 7 changed files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)