### PR TITLE
fix(ingest): accept minted upload token at /ingest/upload (PUT+POST)

### DIFF
--- a/src/memory/api/auth.py
+++ b/src/memory/api/auth.py
@@ -60,6 +60,16 @@ WHITELIST = {
     # (query string for pull, Bearer header for push) inside the endpoints
     # themselves — must bypass OAuth or curl can't reach them.
     "/claude/transfer/",
+    # Generic content upload. The endpoint authenticates the request itself
+    # by verifying the signed ingest token in the ``?token=`` query string
+    # (ingest_tokens.verify_token: HMAC over a domain-tagged payload + exp +
+    # payload-schema check). The signed payload carries the user_id that
+    # scopes the write, so the token IS the authorization for this one
+    # upload — the add_content MCP tool mints it and hands the upload_url to
+    # a non-browser client that has no session cookie. Without this carve-out
+    # the middleware 401s the PUT before the in-endpoint token check fires,
+    # so the documented "PUT the bytes" step is impossible.
+    "/ingest/upload",
     # Slack push-events webhook. Slack POSTs ``event_callback`` payloads
     # here and authenticates via x-slack-signature (HMAC-SHA256 over the
     # body using the per-app signing secret) — it cannot present a

--- a/src/memory/api/ingest.py
+++ b/src/memory/api/ingest.py
@@ -106,7 +106,9 @@ def build_task_kwargs(
     }
 
 
-@router.post("/ingest/upload", response_model=IngestResponse)
+@router.api_route(
+    "/ingest/upload", methods=["PUT", "POST"], response_model=IngestResponse
+)
 async def ingest_upload(
     request: Request,
     token: str,
@@ -114,10 +116,16 @@ async def ingest_upload(
 ) -> IngestResponse:
     """Token-authenticated upload endpoint.
 
-    The signed token encodes the declared MIME, filename, tags, metadata, and
-    the user who minted it. The raw request body is read under a generous cap
-    (the bucket and its specific cap are resolved from the bytes in
-    ``land_and_dispatch``), then dispatched as a Celery task.
+    The signed token in the ``?token=`` query string is the sole
+    authorization (verified here, not by the session middleware — the path
+    is whitelisted), so a non-browser client following the minted
+    ``upload_url`` can upload with no session cookie. The token encodes the
+    declared MIME, filename, tags, metadata, and the user who minted it.
+
+    The add_content tool documents the call as a PUT; POST is accepted too so
+    either verb reaches the same handler. The raw request body is read under a
+    generous cap (the bucket and its specific cap are resolved from the bytes
+    in ``land_and_dispatch``), then dispatched as a Celery task.
     """
     try:
         intent = ingest_tokens.verify_token(token)

--- a/tests/memory/api/test_auth.py
+++ b/tests/memory/api/test_auth.py
@@ -43,6 +43,10 @@ from memory.common import settings
         "/polls/respond/abc-123",
         "/claude/transfer/pull",
         "/claude/transfer/push",
+        # Generic content upload: authorized by the signed ingest token in
+        # the query string, not a session cookie. Must bypass the middleware
+        # or the minted upload_url is unusable from a non-browser client.
+        "/ingest/upload",
         # Slack push-events webhook authenticates via x-slack-signature
         # (HMAC over body), not session cookies. Without this carve-out
         # the AuthenticationMiddleware 401s every Slack POST before the
@@ -110,6 +114,12 @@ def test_is_whitelisted_path_lets_real_routes_through(path):
         "/slack/apps/123",
         "/slack/channels/456",
         "/slack/eventslog",  # prefix-overrun against /slack/events
+        # Prefix-overrun guards against the /ingest/upload carve-out: only
+        # the exact upload path is token-authed; siblings stay session-gated.
+        "/ingest",
+        "/ingest/uploads",  # overrun against /ingest/upload
+        "/ingest/upload-config",
+        "/ingestxxx",
         "",
     ],
 )
@@ -250,6 +260,13 @@ def test_claude_session_pattern_hex_floor_matches_token_hex_16():
         ("GET", "/.well-known/oauth-protected-resource"),
         ("GET", "/authorize"),
         ("POST", "/token"),
+        # The ingest upload endpoint authenticates via its signed ?token=,
+        # not a session — the middleware must pass both the documented PUT
+        # and the also-accepted POST through to the in-endpoint token check.
+        # A bad token reaches the handler and gets a 403 (not a 401 from the
+        # middleware); the point of this case is purely "not 401".
+        ("PUT", "/ingest/upload?token=v1.bad.sig"),
+        ("POST", "/ingest/upload?token=v1.bad.sig"),
     ],
 )
 def test_oauth_public_endpoints_bypass_auth_middleware(

--- a/tests/memory/api/test_ingest_endpoint.py
+++ b/tests/memory/api/test_ingest_endpoint.py
@@ -68,11 +68,14 @@ def _make_dispatch_result(job_id=7, celery_task_id="abc", status="queued", is_ne
     return result
 
 
-def test_upload_lands_and_dispatches(client, user, tmp_path, monkeypatch):
+@pytest.mark.parametrize("method", ["PUT", "POST"])
+def test_upload_lands_and_dispatches(client, user, tmp_path, monkeypatch, method):
+    # PUT is the verb the add_content tool documents for the minted
+    # upload_url; POST is accepted too. Both must reach the handler.
     monkeypatch.setattr(settings, "MISC_STORAGE_DIR", tmp_path / "misc")
     token = _mint(user.id)
     with patch("memory.api.ingest.dispatch_job", return_value=_make_dispatch_result()) as dispatch:
-        resp = client.post(f"/ingest/upload?token={token}", content=b"%PDF-1.4 fake")
+        resp = client.request(method, f"/ingest/upload?token={token}", content=b"%PDF-1.4 fake")
     assert resp.status_code == 200
     body = resp.json()
     assert body["job_id"] == 7
@@ -81,6 +84,15 @@ def test_upload_lands_and_dispatches(client, user, tmp_path, monkeypatch):
     dispatched_kwargs = dispatch.call_args.kwargs["task_kwargs"]
     assert dispatched_kwargs["mime_type"] == "application/pdf"
     assert dispatched_kwargs["doc_metadata"] == {"src": "x"}
+
+
+@pytest.mark.parametrize("method", ["GET", "DELETE", "PATCH"])
+def test_upload_rejects_disallowed_methods(client, user, method):
+    # The route deliberately registers only PUT+POST. Pin the narrowing so a
+    # future widening of ``methods=`` has to update this test on purpose.
+    token = _mint(user.id)
+    resp = client.request(method, f"/ingest/upload?token={token}", content=b"x")
+    assert resp.status_code == 405
 
 
 def test_upload_rejects_bad_token(client):


### PR DESCRIPTION
## Problem

The `add_content` MCP tool, when content is too large to inline, returns a signed `upload_url` and tells the caller to PUT the bytes there. But **every** token-authenticated PUT to `/ingest/upload` returned `401 Authentication required` / `Invalid or expired session` — so a headless/external client (exactly what calls an MCP tool) could never complete the upload. (Reported bug, 2026-05-31.)

## Root cause — two defects, both making the documented flow unreachable

1. **Missing auth carve-out.** `/ingest/upload` was not in `AuthenticationMiddleware`'s `WHITELIST`, so the middleware demanded a session **before** the endpoint's own `verify_token()` ran. The endpoint is designed to be self-authenticating — it takes only `token`, verifies the signed payload, and has no session dependency — exactly like the existing `/claude/transfer/` and `/slack/events/` carve-outs. The "Invalid or expired session" body was the tell: the middleware's session check, not the token check.

2. **HTTP method mismatch.** The route was `@router.post`, but the tool contract documents "PUT the bytes". Pre-routing, the middleware 401 masked this; once auth was fixed, a PUT would have hit 405.

**Why tests never caught it:** the whole API suite runs with `settings.DISABLE_AUTH = True`, which short-circuits the middleware — so the production auth path for this endpoint was never exercised.

## Fix

- `auth.py` — add `/ingest/upload` to `WHITELIST` (bare/exact-match entry) so the in-endpoint token check is the authority. The signed token carries `user_id` and `exp`; forging it requires the HMAC secret, so there is no escalation path and siblings like `/ingest/uploads` stay session-gated.
- `ingest.py` — route now accepts `PUT` (documented verb) and `POST` via `@router.api_route`.
- Tests — regression coverage that exercises the **real** middleware path (`DISABLE_AUTH=False`), pins exact-match whitelisting against prefix-overrun siblings (`/ingest`, `/ingest/uploads`, `/ingest/upload-config`, `/ingestxxx`), parametrizes the happy path over PUT/POST, and asserts disallowed verbs (GET/DELETE/PATCH) → 405.

## Verification

- 141 tests across `test_auth.py` + `test_ingest_endpoint.py` pass (run against the working tree, post-merge with `origin/master`).
- Reviewed over two rounds via differ-review (verdict: Approve, 0 blocking). Confirmed: no prefix-overrun bypass, no collateral un-authing of sibling `/ingest`-prefixed routes, `verify_token` runs before the request body is read (no unbounded pre-auth read), and `user_id` is signed into the payload (no privilege escalation).

## Out of scope

The related nginx 413 is infra-managed (no nginx config in this repo) and reported already fixed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)