### PR TITLE
feat(ui): add Check Questions widget

### DIFF
--- a/frontend/src/App.test.tsx
+++ b/frontend/src/App.test.tsx
@@ -43,6 +43,7 @@ vi.mock('@/components', () => ({
   ConfigSources: () => <div>SNAPSHOTS</div>,
   CeleryOverview: () => <div>CELERY</div>,
   ScheduledTasks: () => <div>SCHEDULED</div>,
+  Check: () => <div>CHECK</div>,
   ReportsPage: () => <div>REPORTS</div>,
 }))
 vi.mock('@/components/polls', () => ({
@@ -163,6 +164,23 @@ describe('App routing & auth', () => {
     setPath('/ui/celery')
     render(<App />)
     expect(screen.getByText('CELERY')).toBeInTheDocument()
+  })
+
+  it('gates the check route behind the check scope (redirects without it)', async () => {
+    authState.isAuthenticated = true
+    authState.hasScope = vi.fn((s) => s !== 'check')
+    setPath('/ui/check')
+    render(<App />)
+    await waitFor(() => expect(screen.getByText('DASHBOARD')).toBeInTheDocument())
+    expect(screen.queryByText('CHECK')).not.toBeInTheDocument()
+  })
+
+  it('renders check for a user with the check scope', () => {
+    authState.isAuthenticated = true
+    authState.hasScope = vi.fn(() => true)
+    setPath('/ui/check')
+    render(<App />)
+    expect(screen.getByText('CHECK')).toBeInTheDocument()
   })
 
   it('lazily renders ClaudeSessions for an authenticated user', async () => {

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -3,7 +3,7 @@ import { BrowserRouter as Router, Routes, Route, Navigate, useNavigate, useLocat
 
 import { useAuth } from '@/hooks/useAuth'
 import { useOAuth } from '@/hooks/useOAuth'
-import { Loading, LoginPrompt, AuthError, Dashboard, Search, Sources, Calendar, Tasks, NotesPage, Jobs, DockerLogs, ConfigSources, CeleryOverview, ScheduledTasks, ReportsPage } from '@/components'
+import { Loading, LoginPrompt, AuthError, Dashboard, Search, Sources, Calendar, Tasks, NotesPage, Jobs, DockerLogs, ConfigSources, CeleryOverview, ScheduledTasks, Check, ReportsPage } from '@/components'
 import { PollList, PollCreate, PollEdit, PollRespond, PollResults } from '@/components/polls'
 import { UserSettings, UserManagement } from '@/components/users'
 import { PeopleManagement } from '@/components/people'
@@ -219,6 +219,16 @@ const AuthWrapper = () => {
       <Route path="/ui/scheduled-tasks" element={
         isAuthenticated ? (
           <ScheduledTasks />
+        ) : (
+          <Navigate to="/ui/login" replace />
+        )
+      } />
+
+      <Route path="/ui/check" element={
+        isAuthenticated && hasScope('check') ? (
+          <Check />
+        ) : isAuthenticated ? (
+          <Navigate to="/ui/dashboard" replace />
         ) : (
           <Navigate to="/ui/login" replace />
         )

--- a/frontend/src/components/Dashboard.tsx
+++ b/frontend/src/components/Dashboard.tsx
@@ -81,6 +81,13 @@ const Dashboard = ({ onLogout, user, hasScope }: DashboardProps) => {
                             <h3 className="text-slate-800 text-xl mb-2 font-semibold">Polls</h3>
                             <p className="text-gray-600 text-base">Schedule meetings with availability polls</p>
                         </Link>
+
+                        {hasScope('check') && (
+                            <Link to="/ui/check" className="bg-white p-8 rounded-xl shadow-md text-center transition-all cursor-pointer no-underline text-inherit block hover:-translate-y-0.5 hover:shadow-lg">
+                                <h3 className="text-slate-800 text-xl mb-2 font-semibold">Check Questions</h3>
+                                <p className="text-gray-600 text-base">Submit questions to verify, research, or link, and see answers</p>
+                            </Link>
+                        )}
                     </div>
                 </section>
 

--- a/frontend/src/components/check/Check.test.tsx
+++ b/frontend/src/components/check/Check.test.tsx
@@ -1,0 +1,113 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { renderWithRouter, screen, waitFor } from '@/test/utils'
+import userEvent from '@testing-library/user-event'
+import type { CheckJob } from '@/hooks/useCheck'
+import { Check } from './index'
+
+const listJobs = vi.fn()
+const ask = vi.fn()
+const deleteJob = vi.fn()
+
+vi.mock('@/hooks/useCheck', () => ({
+  useCheck: () => ({ listJobs, ask, deleteJob }),
+  PAGE_LIMIT: 200,
+}))
+
+const makeJob = (o: Partial<CheckJob> = {}): CheckJob => ({
+  job_id: 'chk_1',
+  status: 'ok',
+  mode: 'research',
+  text: 'is the sky blue?',
+  result: { answer: 'yes, it is' },
+  error: null,
+  submitted_at: new Date().toISOString(),
+  completed_at: new Date().toISOString(),
+  ...o,
+})
+
+beforeEach(() => {
+  listJobs.mockReset().mockResolvedValue([])
+  ask.mockReset().mockResolvedValue({ job_id: 'chk_new', status: 'queued' })
+  deleteJob.mockReset().mockResolvedValue(undefined)
+})
+
+describe('Check', () => {
+  it('shows loading then the empty state', async () => {
+    renderWithRouter(<Check />)
+    expect(screen.getByText('Loading questions...')).toBeInTheDocument()
+    await waitFor(() => expect(screen.getByText('No questions yet')).toBeInTheDocument())
+  })
+
+  it('renders an error state with retry', async () => {
+    listJobs.mockRejectedValueOnce(new Error('boom'))
+    renderWithRouter(<Check />)
+    await waitFor(() => expect(screen.getByText('boom')).toBeInTheDocument())
+  })
+
+  it('renders a job card with question, answer, mode and status', async () => {
+    listJobs.mockResolvedValue([makeJob()])
+    renderWithRouter(<Check />)
+    await waitFor(() => expect(screen.getByText('is the sky blue?')).toBeInTheDocument())
+    expect(screen.getByText('yes, it is')).toBeInTheDocument()
+    expect(screen.getByText('research')).toBeInTheDocument()
+    expect(screen.getByText('Answered', { selector: 'span' })).toBeInTheDocument()
+    expect(screen.getByText('1 answered')).toBeInTheDocument()
+  })
+
+  it('shows the error message for a failed job', async () => {
+    listJobs.mockResolvedValue([makeJob({ status: 'error', result: null, error: 'worker exploded' })])
+    renderWithRouter(<Check />)
+    await waitFor(() => expect(screen.getByText('worker exploded')).toBeInTheDocument())
+  })
+
+  it('fetches the full list once and filters by status in-memory', async () => {
+    listJobs.mockResolvedValue([
+      makeJob({ job_id: 'a', status: 'ok', text: 'answered one' }),
+      makeJob({ job_id: 'b', status: 'queued', result: null, completed_at: null, text: 'queued one' }),
+    ])
+    renderWithRouter(<Check />)
+    await waitFor(() => expect(screen.getByText('answered one')).toBeInTheDocument())
+    expect(screen.getByText('queued one')).toBeInTheDocument()
+    // listJobs is called once, with no status arg — filtering is client-side.
+    expect(listJobs).toHaveBeenCalledTimes(1)
+    expect(listJobs).toHaveBeenLastCalledWith()
+
+    await userEvent.click(screen.getByRole('button', { name: 'Queued' }))
+    // No refetch on tab change; the answered job is filtered out of the display.
+    expect(listJobs).toHaveBeenCalledTimes(1)
+    await waitFor(() => expect(screen.queryByText('answered one')).not.toBeInTheDocument())
+    expect(screen.getByText('queued one')).toBeInTheDocument()
+  })
+
+  it('flags counts as approximate and shows a notice at the 200-job cap', async () => {
+    const jobs = Array.from({ length: 200 }, (_, i) =>
+      makeJob({ job_id: `chk_${i}`, status: 'ok', text: `q ${i}` }),
+    )
+    listJobs.mockResolvedValue(jobs)
+    renderWithRouter(<Check />)
+    await waitFor(() =>
+      expect(screen.getByText('Showing the 200 most recent questions.')).toBeInTheDocument(),
+    )
+    expect(screen.getByText('200+ answered')).toBeInTheDocument()
+  })
+
+  it('submits a new question through the ask form and reloads', async () => {
+    listJobs.mockResolvedValue([])
+    renderWithRouter(<Check />)
+    await waitFor(() => expect(screen.getByText('No questions yet')).toBeInTheDocument())
+    await userEvent.click(screen.getByRole('button', { name: '+ New question' }))
+    await userEvent.type(screen.getByPlaceholderText(/What would you like to verify/), 'why is the sky blue?')
+    await userEvent.click(screen.getByRole('button', { name: 'Ask' }))
+    await waitFor(() => expect(ask).toHaveBeenCalledWith({ text: 'why is the sky blue?', mode: 'research' }))
+  })
+
+  it('deletes a job after confirmation', async () => {
+    listJobs.mockResolvedValue([makeJob()])
+    renderWithRouter(<Check />)
+    await waitFor(() => expect(screen.getByText('is the sky blue?')).toBeInTheDocument())
+    await userEvent.click(screen.getByRole('button', { name: 'Delete' }))
+    await userEvent.click(screen.getByRole('button', { name: 'Yes' }))
+    await waitFor(() => expect(deleteJob).toHaveBeenCalledWith('chk_1'))
+    await waitFor(() => expect(screen.queryByText('is the sky blue?')).not.toBeInTheDocument())
+  })
+})

--- a/frontend/src/components/check/Check.tsx
+++ b/frontend/src/components/check/Check.tsx
@@ -1,0 +1,343 @@
+import { useState, useEffect, useCallback } from 'react'
+import { Link } from 'react-router-dom'
+import { useCheck, PAGE_LIMIT, CheckJob, CheckMode, CheckStatus, AskBody } from '@/hooks/useCheck'
+import { formatRelativeTime } from '@/components/sources/shared'
+
+const STATUS_COLORS: Record<CheckStatus, string> = {
+  queued: 'bg-yellow-100 text-yellow-700',
+  in_flight: 'bg-blue-100 text-blue-700',
+  ok: 'bg-green-100 text-green-700',
+  error: 'bg-red-100 text-red-700',
+  expired: 'bg-slate-100 text-slate-500',
+}
+
+const MODE_COLORS: Record<CheckMode, string> = {
+  verify: 'bg-purple-100 text-purple-700',
+  research: 'bg-indigo-100 text-indigo-700',
+  link: 'bg-teal-100 text-teal-700',
+}
+
+const STATUS_LABELS: Record<CheckStatus, string> = {
+  queued: 'Queued',
+  in_flight: 'In progress',
+  ok: 'Answered',
+  error: 'Error',
+  expired: 'Expired',
+}
+
+const MODES: CheckMode[] = ['research', 'verify', 'link']
+
+// `listJobs` fetches a single PAGE_LIMIT-sized page (see useCheck); the UI has no
+// pagination. With CHECK retention at 14 days, that cap is assumed to comfortably
+// cover a user's live questions, so paging is a deliberate v2 follow-up. When we
+// do hit the cap the header counts and filter tabs only reflect the most-recent
+// page, so we flag them as approximate instead of silently undercounting.
+
+const inputClass = 'w-full px-3 py-1.5 border border-slate-200 rounded text-sm focus:outline-none focus:ring-1 focus:ring-primary'
+const labelClass = 'block text-xs font-medium text-slate-500 mb-1'
+
+// Pull a human-readable answer out of an arbitrary result dict: prefer a
+// top-level `answer` string, otherwise pretty-print the whole object.
+function renderAnswer(result: Record<string, unknown> | null): string | null {
+  if (!result || Object.keys(result).length === 0) return null
+  const answer = result.answer
+  if (typeof answer === 'string') return answer
+  return JSON.stringify(result, null, 2)
+}
+
+// --- Ask Form ---
+
+interface AskFormProps {
+  onAsk: (body: AskBody) => Promise<void>
+  onCancel: () => void
+  saving: boolean
+  error: string | null
+}
+
+const AskForm = ({ onAsk, onCancel, saving, error }: AskFormProps) => {
+  const [text, setText] = useState('')
+  const [mode, setMode] = useState<CheckMode>('research')
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault()
+    if (!text.trim()) return
+    await onAsk({ text: text.trim(), mode })
+  }
+
+  return (
+    <form onSubmit={handleSubmit} className="space-y-3 border border-slate-200 rounded-lg p-4 bg-slate-50">
+      <div>
+        <label className={labelClass}>Question</label>
+        <textarea
+          value={text}
+          onChange={e => setText(e.target.value)}
+          rows={3}
+          placeholder="What would you like to verify, research, or link?"
+          className={inputClass}
+          autoFocus
+        />
+      </div>
+      <div>
+        <label className={labelClass}>Mode</label>
+        <select value={mode} onChange={e => setMode(e.target.value as CheckMode)} className={inputClass}>
+          {MODES.map(m => (
+            <option key={m} value={m}>{m.charAt(0).toUpperCase() + m.slice(1)}</option>
+          ))}
+        </select>
+      </div>
+      {error && <p className="text-sm text-red-600">{error}</p>}
+      <div className="flex gap-2 pt-1">
+        <button
+          type="submit"
+          disabled={saving || !text.trim()}
+          className="bg-primary text-white py-1.5 px-4 rounded text-sm hover:bg-primary-dark disabled:bg-slate-300"
+        >
+          {saving ? 'Submitting...' : 'Ask'}
+        </button>
+        <button
+          type="button"
+          onClick={onCancel}
+          disabled={saving}
+          className="bg-slate-100 text-slate-700 py-1.5 px-4 rounded text-sm hover:bg-slate-200"
+        >
+          Cancel
+        </button>
+      </div>
+    </form>
+  )
+}
+
+// --- Job Card ---
+
+interface JobCardProps {
+  job: CheckJob
+  onDelete: (jobId: string) => Promise<void>
+}
+
+const JobCard = ({ job, onDelete }: JobCardProps) => {
+  const [confirmDelete, setConfirmDelete] = useState(false)
+  const [deleting, setDeleting] = useState(false)
+
+  const handleDelete = async () => {
+    setDeleting(true)
+    try {
+      await onDelete(job.job_id)
+    } catch {
+      setDeleting(false)
+      setConfirmDelete(false)
+    }
+  }
+
+  // Only surface the answer for a successful job: an errored job can carry a
+  // partial result, and showing both an Answer and the red error line is confusing.
+  const answer = job.status === 'ok' ? renderAnswer(job.result) : null
+
+  return (
+    <li className="bg-white p-4 rounded-lg shadow-sm border-l-4 border-slate-200">
+      <div className="flex items-start gap-3">
+        <div className="flex-1 min-w-0">
+          <div className="flex items-center gap-2 mb-1 flex-wrap">
+            <span className={`px-2 py-0.5 rounded text-xs font-medium ${MODE_COLORS[job.mode] || 'bg-slate-100 text-slate-600'}`}>
+              {job.mode}
+            </span>
+            <span className={`px-2 py-0.5 rounded text-xs font-medium ${STATUS_COLORS[job.status] || 'bg-slate-100 text-slate-600'}`}>
+              {STATUS_LABELS[job.status] || job.status}
+            </span>
+          </div>
+
+          <p className="text-sm font-medium text-slate-800 whitespace-pre-wrap break-words">{job.text}</p>
+
+          {answer && (
+            <div className="mt-2 border-t border-slate-100 pt-2">
+              <p className="text-xs font-medium text-slate-400 mb-1">Answer</p>
+              <p className="text-sm text-slate-700 whitespace-pre-wrap break-words">{answer}</p>
+            </div>
+          )}
+
+          {job.status === 'error' && job.error && (
+            <p className="text-sm text-red-600 mt-2 whitespace-pre-wrap break-words">{job.error}</p>
+          )}
+
+          <div className="flex gap-4 mt-2 text-xs text-slate-400 flex-wrap">
+            <span>Asked: {formatRelativeTime(job.submitted_at)}</span>
+            {job.completed_at && <span>Answered: {formatRelativeTime(job.completed_at)}</span>}
+          </div>
+        </div>
+
+        <div className="shrink-0">
+          {confirmDelete ? (
+            <span className="flex items-center gap-1 text-sm">
+              <span className="text-red-600">Delete?</span>
+              <button onClick={handleDelete} disabled={deleting} className="text-red-600 font-medium hover:underline">
+                {deleting ? '...' : 'Yes'}
+              </button>
+              <button onClick={() => setConfirmDelete(false)} className="text-slate-500 hover:underline">
+                No
+              </button>
+            </span>
+          ) : (
+            <button
+              onClick={() => setConfirmDelete(true)}
+              className="bg-red-50 text-red-600 py-1.5 px-3 rounded text-sm hover:bg-red-100"
+            >
+              Delete
+            </button>
+          )}
+        </div>
+      </div>
+    </li>
+  )
+}
+
+// --- Main Page ---
+
+type StatusFilter = 'all' | CheckStatus
+
+const FILTERS: { value: StatusFilter; label: string }[] = [
+  { value: 'all', label: 'All' },
+  { value: 'queued', label: 'Queued' },
+  { value: 'in_flight', label: 'In progress' },
+  { value: 'ok', label: 'Answered' },
+  { value: 'error', label: 'Error' },
+  { value: 'expired', label: 'Expired' },
+]
+
+const Check = () => {
+  const { listJobs, ask, deleteJob } = useCheck()
+  const [jobs, setJobs] = useState<CheckJob[]>([])
+  const [loading, setLoading] = useState(true)
+  const [error, setError] = useState<string | null>(null)
+  const [statusFilter, setStatusFilter] = useState<StatusFilter>('all')
+
+  const [showAsk, setShowAsk] = useState(false)
+  const [asking, setAsking] = useState(false)
+  const [askError, setAskError] = useState<string | null>(null)
+
+  // Always fetch the full list; filtering happens client-side for display so
+  // the header counts stay accurate and switching tabs doesn't refetch/flash.
+  const loadJobs = useCallback(async () => {
+    setLoading(true)
+    try {
+      const data = await listJobs()
+      setJobs(data)
+      setError(null)
+    } catch (e) {
+      setError(e instanceof Error ? e.message : 'Failed to load questions')
+    } finally {
+      setLoading(false)
+    }
+  }, [listJobs])
+
+  useEffect(() => { loadJobs() }, [loadJobs])
+
+  const handleAsk = async (body: AskBody) => {
+    setAsking(true)
+    setAskError(null)
+    try {
+      await ask(body)
+      setShowAsk(false)
+      await loadJobs()
+    } catch (e) {
+      setAskError(e instanceof Error ? e.message : 'Failed to submit question')
+    } finally {
+      setAsking(false)
+    }
+  }
+
+  const handleDelete = async (jobId: string) => {
+    await deleteJob(jobId)
+    setJobs(prev => prev.filter(j => j.job_id !== jobId))
+  }
+
+  // Counts come from the full set; the displayed list is filtered in-memory.
+  const answeredCount = jobs.filter(j => j.status === 'ok').length
+  const pendingCount = jobs.filter(j => j.status === 'queued' || j.status === 'in_flight').length
+  const visibleJobs = statusFilter === 'all' ? jobs : jobs.filter(j => j.status === statusFilter)
+
+  // We only fetched the most-recent page; at the cap, counts are lower bounds
+  // and older jobs aren't shown. Surface a "+" suffix and a notice so the
+  // numbers don't read as exact totals.
+  const atCap = jobs.length >= PAGE_LIMIT
+  const countSuffix = atCap ? '+' : ''
+
+  return (
+    <div className="min-h-screen bg-slate-50 p-6">
+      <header className="flex items-center gap-4 mb-6 pb-4 border-b border-slate-200">
+        <Link to="/ui/dashboard" className="bg-slate-50 text-slate-600 border border-slate-200 py-2 px-4 rounded-md text-sm hover:bg-slate-100">
+          Back
+        </Link>
+        <h1 className="text-2xl font-semibold text-slate-800 flex-1">Check Questions</h1>
+        <div className="flex gap-3 text-sm">
+          {pendingCount > 0 && <span className="text-blue-600 font-medium">{pendingCount}{countSuffix} pending</span>}
+          <span className="text-green-600 font-medium">{answeredCount}{countSuffix} answered</span>
+        </div>
+      </header>
+
+      <div className="space-y-4">
+        <div className="flex gap-2 items-center flex-wrap">
+          {FILTERS.map(f => (
+            <button
+              key={f.value}
+              className={`py-2 px-4 rounded-lg text-sm font-medium transition-colors ${
+                statusFilter === f.value
+                  ? 'bg-primary text-white'
+                  : 'bg-white text-slate-600 border border-slate-200 hover:bg-slate-50'
+              }`}
+              onClick={() => setStatusFilter(f.value)}
+            >
+              {f.label}
+            </button>
+          ))}
+          <button
+            onClick={() => loadJobs()}
+            className="w-9 h-9 bg-white border border-slate-200 rounded-lg hover:bg-slate-50 text-lg"
+            title="Refresh"
+            aria-label="Refresh question list"
+          >
+            &#8635;
+          </button>
+          <button onClick={() => setShowAsk(v => !v)} className="bg-primary text-white py-1.5 px-3 rounded text-sm hover:bg-primary-dark">
+            {showAsk ? 'Close' : '+ New question'}
+          </button>
+        </div>
+
+        {error && (
+          <div className="bg-red-50 border border-red-200 text-red-700 p-4 rounded-lg flex justify-between items-center">
+            <p>{error}</p>
+            <button onClick={() => loadJobs()} className="text-primary hover:underline">Retry</button>
+          </div>
+        )}
+
+        {showAsk && (
+          <div className="mb-4">
+            <AskForm onAsk={handleAsk} onCancel={() => setShowAsk(false)} saving={asking} error={askError} />
+          </div>
+        )}
+
+        {!loading && atCap && (
+          <p className="text-xs text-slate-400">
+            Showing the {PAGE_LIMIT} most recent questions.
+          </p>
+        )}
+
+        {loading && <div className="text-center py-8 text-slate-500">Loading questions...</div>}
+
+        {!loading && visibleJobs.length === 0 && (
+          <div className="text-center py-12 text-slate-500 bg-white rounded-xl">
+            {statusFilter === 'all' ? 'No questions yet' : `No ${statusFilter} questions`}
+          </div>
+        )}
+
+        {!loading && visibleJobs.length > 0 && (
+          <ul className="space-y-3">
+            {visibleJobs.map(job => (
+              <JobCard key={job.job_id} job={job} onDelete={handleDelete} />
+            ))}
+          </ul>
+        )}
+      </div>
+    </div>
+  )
+}
+
+export default Check

--- a/frontend/src/components/check/index.ts
+++ b/frontend/src/components/check/index.ts
@@ -1,0 +1,1 @@
+export { default as Check } from './Check'

--- a/frontend/src/components/index.ts
+++ b/frontend/src/components/index.ts
@@ -13,6 +13,7 @@ export { default as AuthError } from './auth/AuthError'
 
 export { CeleryOverview } from './celery'
 export { ScheduledTasks } from './scheduled-tasks'
+export { Check } from './check'
 export { ReportsPage } from './reports'
 
 // Note: Metrics, Telemetry, ClaudeSessions are lazy-loaded in App.tsx

--- a/frontend/src/hooks/useCheck.test.ts
+++ b/frontend/src/hooks/useCheck.test.ts
@@ -1,0 +1,86 @@
+import { describe, it, expect, beforeEach } from 'vitest'
+import { renderHook } from '@testing-library/react'
+import { useCheck } from './useCheck'
+import {
+  mockFetch,
+  mockResponse,
+  MockResponseInit,
+  setAuthCookies,
+  clearCookies,
+} from '@/test/utils'
+import { mcpResult } from './mcpEnvelope.testhelper'
+
+beforeEach(() => {
+  clearCookies()
+  setAuthCookies()
+})
+
+function routeMcp(resp: MockResponseInit) {
+  return mockFetch(async (input) => {
+    const url = String(input)
+    if (url.endsWith('/auth/me')) return mockResponse({ json: {} })
+    return mockResponse(resp)
+  })
+}
+
+function bodyArgs(fetchMock: ReturnType<typeof mockFetch>, methodSubstr: string) {
+  const call = fetchMock.mock.calls.find((c) => String(c[0]).includes(`/mcp/${methodSubstr}`))
+  return JSON.parse(call?.[1]?.body as string).params.arguments
+}
+
+const job = {
+  job_id: 'chk_abc',
+  status: 'ok',
+  mode: 'research',
+  text: 'is the sky blue?',
+  result: { answer: 'yes' },
+  error: null,
+  submitted_at: '2026-06-03T00:00:00+00:00',
+  completed_at: '2026-06-03T00:01:00+00:00',
+}
+
+describe('useCheck.listJobs', () => {
+  it('unwraps the jobs array and sends limit=200 by default', async () => {
+    const fetchMock = routeMcp(mcpResult({ jobs: [job] }))
+    const { result } = renderHook(() => useCheck())
+    const jobs = await result.current.listJobs()
+    expect(jobs).toEqual([job])
+    expect(bodyArgs(fetchMock, 'check_list_jobs')).toEqual({ limit: 200 })
+  })
+
+  it('propagates MCP transport errors', async () => {
+    const fetchMock = mockFetch(async (input) => {
+      if (String(input).endsWith('/auth/me')) return mockResponse({ json: {} })
+      return mockResponse({ status: 500, text: 'boom' })
+    })
+    const { result } = renderHook(() => useCheck())
+    await expect(result.current.listJobs()).rejects.toThrow('check_list_jobs failed')
+    expect(fetchMock).toHaveBeenCalled()
+  })
+})
+
+describe('useCheck.ask', () => {
+  it('submits text with the default research mode', async () => {
+    const fetchMock = routeMcp(mcpResult({ job_id: 'chk_new', status: 'queued' }))
+    const { result } = renderHook(() => useCheck())
+    const got = await result.current.ask({ text: 'why?' })
+    expect(got).toEqual({ job_id: 'chk_new', status: 'queued' })
+    expect(bodyArgs(fetchMock, 'check_ask')).toEqual({ text: 'why?', mode: 'research' })
+  })
+
+  it('forwards an explicit mode', async () => {
+    const fetchMock = routeMcp(mcpResult({ job_id: 'chk_new', status: 'queued' }))
+    const { result } = renderHook(() => useCheck())
+    await result.current.ask({ text: 'check this', mode: 'verify' })
+    expect(bodyArgs(fetchMock, 'check_ask')).toEqual({ text: 'check this', mode: 'verify' })
+  })
+})
+
+describe('useCheck.deleteJob', () => {
+  it('calls check_delete with the job id and resolves to undefined', async () => {
+    const fetchMock = routeMcp(mcpResult({ deleted: true, job_id: 'chk_abc' }))
+    const { result } = renderHook(() => useCheck())
+    await expect(result.current.deleteJob('chk_abc')).resolves.toBeUndefined()
+    expect(bodyArgs(fetchMock, 'check_delete')).toEqual({ job_id: 'chk_abc' })
+  })
+})

--- a/frontend/src/hooks/useCheck.ts
+++ b/frontend/src/hooks/useCheck.ts
@@ -1,0 +1,50 @@
+import { useCallback } from 'react'
+import { useMCP } from './useMCP'
+
+export type CheckMode = 'verify' | 'research' | 'link'
+export type CheckStatus = 'queued' | 'in_flight' | 'ok' | 'error' | 'expired'
+
+export interface CheckJob {
+  job_id: string
+  status: CheckStatus
+  mode: CheckMode
+  text: string
+  result: Record<string, unknown> | null
+  error: string | null
+  submitted_at: string
+  completed_at: string | null
+}
+
+export interface AskBody {
+  text: string
+  mode?: CheckMode
+}
+
+// Single page size for the questions list. The backend hard-clamps the list
+// limit to 200 and there's no pagination, so this one constant drives the fetch
+// size, the at-cap detection, and the "showing the N most recent" notice — keep
+// it as the sole source of truth so those can't drift apart.
+export const PAGE_LIMIT = 200
+
+export const useCheck = () => {
+  const { mcpCall } = useMCP()
+
+  const listJobs = useCallback(async (): Promise<CheckJob[]> => {
+    const result = await mcpCall('check_list_jobs', { limit: PAGE_LIMIT })
+    return (result[0] as { jobs?: CheckJob[] })?.jobs ?? []
+  }, [mcpCall])
+
+  const ask = useCallback(async (body: AskBody): Promise<{ job_id: string; status: CheckStatus }> => {
+    const result = await mcpCall('check_ask', {
+      text: body.text,
+      mode: body.mode ?? 'research',
+    })
+    return result[0] as { job_id: string; status: CheckStatus }
+  }, [mcpCall])
+
+  const deleteJob = useCallback(async (jobId: string): Promise<void> => {
+    await mcpCall('check_delete', { job_id: jobId })
+  }, [mcpCall])
+
+  return { listJobs, ask, deleteJob }
+}

--- a/src/memory/api/MCP/servers/check.py
+++ b/src/memory/api/MCP/servers/check.py
@@ -130,7 +130,8 @@ async def list_jobs(
         limit: Maximum jobs to return (default 50, clamped to 1..200).
         offset: Number of matching jobs to skip (default 0).
 
-    Returns: {"jobs": [...]} where each entry has job_id, status, mode, and times.
+    Returns: {"jobs": [...]} where each entry has job_id, status, mode, the
+    original question text, result/error if answered, and times.
     """
     user = get_mcp_current_user()
     if not user or user.id is None:

--- a/src/memory/common/check/schemas.py
+++ b/src/memory/common/check/schemas.py
@@ -73,6 +73,9 @@ class JobSummary(BaseModel):
     job_id: str
     status: JobStatus
     mode: Mode
+    text: str
+    result: dict[str, Any] | None = None
+    error: str | None = None
     submitted_at: str
     completed_at: str | None = None
 
@@ -82,6 +85,9 @@ class JobSummary(BaseModel):
             job_id=rec["job_id"],
             status=cast(JobStatus, rec["status"]),
             mode=cast(Mode, rec["mode"]),
+            text=rec["text"],
+            result=json.loads(rec["result"]) if rec.get("result") else None,
+            error=rec.get("error") or None,
             submitted_at=rec["submitted_at"],
             completed_at=rec.get("completed_at") or None,
         )

--- a/tests/memory/api/MCP/test_check.py
+++ b/tests/memory/api/MCP/test_check.py
@@ -111,6 +111,28 @@ async def test_list_jobs_returns_own(db_session, fake_redis, check_user):
         await ask.fn(text="two")
         result = await list_jobs.fn()
     assert len(result["jobs"]) == 2
+    # The UI lists question text directly, so it must round-trip through the summary.
+    assert {j["text"] for j in result["jobs"]} == {"one", "two"}
+
+
+async def test_list_jobs_includes_answer(db_session, fake_redis, check_user):
+    user, session = check_user
+    job_id = await store.submit_job(
+        fake_redis, user_id=user.id, req=SubmitRequest(text="claim me")
+    )
+    nxt = await store.claim_next(fake_redis, user_id=user.id, wait=0)
+    assert nxt is not None
+    await store.complete_job(
+        fake_redis, job_id, nxt.lease_id, status="ok",
+        result={"answer": "yes"}, error=None,
+    )
+    with mcp_auth_context(session.id):
+        result = await list_jobs.fn()
+    (job,) = result["jobs"]
+    assert job["text"] == "claim me"
+    assert job["status"] == "ok"
+    assert job["result"] == {"answer": "yes"}
+    assert job["error"] is None
 
 
 async def test_delete_removes(db_session, fake_redis, check_user):


### PR DESCRIPTION
## What

Adds a **Check Questions** UI widget for the check job queue (recently-added endpoints/MCP tools).

It lists the current user's questions — showing the question text, the answer (when ready), and status — and supports **deleting** questions and **submitting new** ones (verify / research / link modes).

## Changes

**Frontend**
- `useCheck` hook over the existing `check_ask` / `check_list_jobs` / `check_delete` MCP tools. `PAGE_LIMIT` is the single source of truth for fetch size, at-cap detection, and the "showing N most recent" notice.
- `Check` page: full list fetched once and filtered client-side, so header counts stay accurate under every filter (flagged `200+` at the page cap, with a notice). Per-card delete-with-confirm, ask form, status filter tabs, refresh.
- `/ui/check` route + Dashboard card, both gated on the `check` scope.

**Backend**
- Enrich `JobSummary` (returned by `check_list_jobs`) with `text` / `result` / `error` so the list shows question + answer in a single call.

## Tests
- Frontend: full suite green (incl. new `useCheck.test.ts`, `Check.test.tsx`, App route-gating tests); ESLint clean.
- Backend: `test_store.py` passes; added `test_list_jobs_includes_answer`. DB-backed MCP tests collect cleanly (skip locally — sandbox Postgres unreachable).

Survived 3 rounds of iterative differ review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)