### PR TITLE
fix(notify): immediate Discord notifications silently lost on int snowflake target

### DIFF
--- a/src/memory/api/MCP/servers/meta.py
+++ b/src/memory/api/MCP/servers/meta.py
@@ -165,7 +165,8 @@ def _get_current_user(session: DBSession) -> dict:
         # Add Discord from Person if not already on User
         if not user_info.get("discord_accounts") and person.discord_accounts:
             user_info["discord_accounts"] = {
-                acct.id: acct.username for acct in person.discord_accounts
+                # str keys to match User.serialize() and the JSON-RPC wire shape.
+                str(acct.id): acct.username for acct in person.discord_accounts
             }
 
         # Add Slack from Person contact_info if no credentials found
@@ -337,7 +338,11 @@ def get_notification_channel(user_info: dict, preferred: str | None) -> tuple[st
     if discord_accounts and discord_bots:
         discord_id = next(iter(discord_accounts.keys()), None)
         if discord_id:
-            channels.append(("discord", discord_id, {"discord_bot_id": discord_bots[0]}))
+            # Discord ids are int snowflakes in serialize(); coerce to str so the
+            # identifier survives the celery JSON boundary as the str the
+            # downstream .isdigit() classification expects (slack/email are
+            # already strings here).
+            channels.append(("discord", str(discord_id), {"discord_bot_id": discord_bots[0]}))
 
     # Slack
     slack_accounts = user.get("slack_accounts", {})
@@ -439,7 +444,11 @@ async def notify_user(
                        If None, sends immediately. If set, schedules for later.
 
     Returns:
-        Dict with success status and delivery details
+        For a scheduled send: ``{"success": True, "scheduled": True, ...}`` — a
+        notification row is durably committed.
+        For an immediate send: ``{"queued": True, "scheduled": False, ...}`` —
+        the delivery task is enqueued but NOT confirmed delivered (fire-and-forget,
+        no row/metric to read back).
     """
     if not subject:
         raise ValueError("Subject is required")
@@ -502,8 +511,11 @@ async def notify_user(
         SEND_NOTIFICATION,
         args=[channel_type, channel_identifier, full_message, user_id, subject, extra_data],
     )
+    # "queued", not "success": the celery task is enqueued but delivery is not
+    # confirmed here. There is no row/metric to read back, so the caller can't
+    # learn whether the send actually landed — don't imply it did.
     return {
-        "success": True,
+        "queued": True,
         "scheduled": False,
         "notification_id": None,
         "channel_type": channel_type,

--- a/src/memory/common/db/models/users.py
+++ b/src/memory/common/db/models/users.py
@@ -156,7 +156,10 @@ class User(Base):
             "user_type": self.user_type,
             "scopes": self.scopes or [],
             "discord_accounts": {
-                account.id: account.username for account in self.discord_accounts
+                # str keys: Discord ids are int snowflakes, but JSON object keys
+                # are always strings — coerce here so in-process consumers see the
+                # same shape clients get after the JSON-RPC boundary.
+                str(account.id): account.username for account in self.discord_accounts
             },
             "discord_bots": [bot.id for bot in self.discord_bots],
         }

--- a/src/memory/common/discord_data.py
+++ b/src/memory/common/discord_data.py
@@ -24,20 +24,23 @@ from memory.common.db.models import (
 
 
 def discord_channel_for_target(
-    session: DBSession, target: str
+    session: DBSession, target: str | int
 ) -> DiscordChannel | None:
     """Return the DiscordChannel a target id refers to, or None.
 
     Discord channel and user ids are indistinguishable snowflakes, so a target
     is a channel iff it's a known DiscordChannel row. Shared by upsert-time
     validation and dispatch so the two never classify the same id differently.
+    Accepts str or int: a raw snowflake from a celery JSON boundary stays int,
+    and this is the one place that classifies it.
     """
+    target = str(target)
     if not target.isdigit():
         return None
     return session.get(DiscordChannel, int(target))
 
 
-def discord_target_is_channel(session: DBSession, target: str) -> bool:
+def discord_target_is_channel(session: DBSession, target: str | int) -> bool:
     """True if the target id is a known Discord channel (else a user DM)."""
     return discord_channel_for_target(session, target) is not None
 

--- a/src/memory/workers/tasks/scheduled_tasks.py
+++ b/src/memory/workers/tasks/scheduled_tasks.py
@@ -104,6 +104,9 @@ def send_via_discord(params: NotificationParams) -> bool:
     if not target:
         logger.error("No Discord target for notification")
         return False
+    # Snowflake ids can arrive as int across the celery boundary; the collector
+    # API and classification both want a str.
+    target = str(target)
 
     with make_session() as session:
         bot_id = resolve_discord_bot_id(session, params)

--- a/tests/memory/api/MCP/test_meta.py
+++ b/tests/memory/api/MCP/test_meta.py
@@ -261,8 +261,9 @@ async def test_get_user_person_discord_fallback(db_session, admin_user, admin_se
 
     assert result["authenticated"] is True
     # User.serialize() returns empty discord_accounts (none linked to user directly)
-    # so Person's discord accounts should be used as fallback
-    assert result["user"]["discord_accounts"] == {999: "person_discord"}
+    # so Person's discord accounts should be used as fallback. Keys are str:
+    # Discord snowflakes are ints, but JSON object keys are always strings.
+    assert result["user"]["discord_accounts"] == {"999": "person_discord"}
 
 
 @pytest.mark.asyncio

--- a/tests/memory/api/MCP/test_meta_notify.py
+++ b/tests/memory/api/MCP/test_meta_notify.py
@@ -4,9 +4,31 @@ from unittest.mock import patch
 import pytest
 
 from memory.api.MCP.servers import meta
-from memory.api.MCP.servers.meta import format_notification_message
+from memory.api.MCP.servers.meta import (
+    format_notification_message,
+    get_notification_channel,
+)
 from memory.common.db.models import ScheduledTask
 from tests.conftest import mcp_auth_context
+
+
+def test_get_notification_channel_coerces_int_discord_id():
+    # User.serialize() keys discord_accounts by int snowflake; the identifier
+    # must be coerced to str so it survives the celery JSON boundary as the
+    # str the downstream .isdigit() classification expects.
+    user_info = {
+        "user": {
+            "discord_accounts": {123456789: "someuser"},
+            "discord_bots": [7],
+        }
+    }
+    channel = get_notification_channel(user_info, None)
+    assert channel is not None
+    ch_type, ch_id, extra = channel
+    assert ch_type == "discord"
+    assert ch_id == "123456789"
+    assert isinstance(ch_id, str)
+    assert extra == {"discord_bot_id": 7}
 
 
 def test_format_notification_message_with_url():
@@ -31,6 +53,9 @@ async def test_notify_user_immediate_creates_no_rows(
         result = await meta.notify_user.fn(subject="Hi", message="body")
 
     assert result["scheduled"] is False
+    # Immediate sends report "queued", not "success": delivery isn't confirmed.
+    assert result["queued"] is True
+    assert "success" not in result
     assert (
         db_session.query(ScheduledTask)
         .filter(ScheduledTask.user_id == regular_user.id)

--- a/tests/memory/common/db/models/test_users.py
+++ b/tests/memory/common/db/models/test_users.py
@@ -1,6 +1,7 @@
 from datetime import datetime, timedelta, timezone
 
 import pytest
+from memory.common.db.models.discord import DiscordUser
 from memory.common.db.models.users import (
     hash_password,
     verify_password,
@@ -169,6 +170,24 @@ def test_user_serialization_human(db_session):
     assert serialized["email"] == "serialize@example.com"
     assert serialized["user_type"] == "human"
     assert "password_hash" not in serialized  # Should not expose password hash
+
+
+def test_user_serialization_discord_keys_are_str(db_session):
+    # Discord snowflakes are int columns, but JSON object keys are always
+    # strings — serialize() must coerce so in-process consumers see the same
+    # shape clients get after the JSON-RPC boundary.
+    user = HumanUser.create_with_password(
+        email="ds@example.com", name="DS", password="password123"
+    )
+    db_session.add(user)
+    db_session.flush()
+    db_session.add(
+        DiscordUser(id=123456789, username="someuser", system_user_id=user.id)
+    )
+    db_session.commit()
+
+    serialized = user.serialize()
+    assert serialized["discord_accounts"] == {"123456789": "someuser"}
 
 
 def test_user_serialization_bot(db_session):

--- a/tests/memory/workers/tasks/test_scheduled_tasks.py
+++ b/tests/memory/workers/tasks/test_scheduled_tasks.py
@@ -49,7 +49,9 @@ def test_slack_target_is_dm(target, is_dm):
     "target,is_channel",
     [
         ("424242", True),  # known channel id (created below)
+        (424242, True),  # int snowflake (celery JSON boundary) ⇒ same answer
         ("999999", False),  # unknown id ⇒ treated as user DM
+        (999999, False),  # int unknown id ⇒ user DM, not a crash
         ("not-a-number", False),
     ],
 )
@@ -109,6 +111,27 @@ def test_send_via_discord_routes_to_dm(monkeypatch):
     )
     assert calls["dm"] == (7, "778899", "hello")
     assert "channel" not in calls
+
+
+def test_send_via_discord_normalizes_int_target(monkeypatch):
+    # An int snowflake target (raw from serialize() across the celery JSON
+    # boundary) must not crash and must reach the collector API as a str.
+    calls = {}
+    monkeypatch.setattr(scheduled_tasks, "make_session", null_session)
+    monkeypatch.setattr(scheduled_tasks, "resolve_discord_bot_id", lambda s, p: 7)
+    monkeypatch.setattr(
+        scheduled_tasks, "discord_target_is_channel", lambda s, t: False
+    )
+    monkeypatch.setattr(
+        scheduled_tasks.discord_utils,
+        "send_dm",
+        lambda bot, target, msg: calls.update(dm=(bot, target, msg)) or True,
+    )
+    assert (
+        scheduled_tasks.send_via_discord(make_notification_params("discord", 778899))
+        is True
+    )
+    assert calls["dm"] == (7, "778899", "hello")
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Problem

`meta_notify_user` returned `{"success": true, "channel_type": "discord"}` but **no Discord DM ever arrived** — every immediate Discord notification since ~2026-05-30 was silently dropped. The worker crashed on all 3 celery attempts with:

```
AttributeError: 'int' object has no attribute 'isdigit'
  scheduled_tasks.py send_via_discord → discord_data.py discord_channel_for_target → target.isdigit()
```

### Root cause — int/str mismatch across the celery boundary

1. `User.serialize()` keys `discord_accounts` by the **int** snowflake (`account.id`).
2. `notify_user` picks that int and passes it as the celery task `target`; JSON serialization preserves it as int.
3. The worker classifies channel-vs-DM via `target.isdigit()`, which assumes `str` → `AttributeError`, task fails, message lost (no retry, no dead-letter, no DB record).

**Why only the immediate path broke:** scheduled notifications round-trip through `ScheduledTask.notification_target` (a `String` column), so the int is coerced to str by the DB. The immediate path (added 2026-05-29) skips the DB; the `.isdigit()` classification landed 2026-05-30. Each commit was fine alone — together they broke every immediate Discord send. Slack/email use string identifiers throughout and were unaffected.

## Fix (layered)

- **Source** — `get_notification_channel` coerces the Discord id to `str` (slack/email were already str).
- **Classification** — `discord_channel_for_target` / `discord_target_is_channel` accept `str | int` and normalize; the one canonical place that classifies a snowflake.
- **Dispatch** — `send_via_discord` `str()`s the target before `send_dm`/`send_to_channel` (the collector API wants str).

## Related fix — `get_user` public contract

`User.serialize()` and the `_get_current_user` Person fallback emitted `discord_accounts` keyed by int. JSON object keys are always strings, so in-process callers saw `{123456789: …}` while MCP clients over the wire saw `{"123456789": …}`. Both now coerce to str, so the shapes match.

## Honesty fix — `success` → `queued`

The immediate-send return now reports `{"queued": true, "scheduled": false, …}` instead of `success`: a fire-and-forget enqueue is **not** a delivery confirmation and shouldn't imply one. There is no row/metric to read back. Scheduled sends keep `success` (a notification row is durably committed). Clients should branch on the shared `scheduled` key.

## Tests

- int-target classification (`discord_target_is_channel`) and dispatch (`send_via_discord`) no longer crash and route correctly
- int → str channel coercion in `get_notification_channel`
- str-keyed `User.serialize()` and the `get_user` Person fallback
- the `queued` immediate-send return shape (`"success" not in result`)

All passing; verified across `test_meta`, `test_meta_notify`, `test_users`, `test_notification_targets`, `test_scheduled_tasks`, `test_teams` (no regressions).

🤖 Generated with [Claude Code](https://claude.com/claude-code)