### PR TITLE
fix(api): stop per-request MCP session leak; cap glibc arenas (#96)

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -49,6 +49,9 @@ x-worker-base: &worker-base
   env_file: [.env]
   environment: &worker-env
     <<: *env
+    # Same arena cap as the api service (#96): workers hold large transient
+    # ingest payloads (ebooks, photos) that otherwise pin RSS at its peak.
+    MALLOC_ARENA_MAX: 2
     POSTGRES_PASSWORD_FILE: /run/secrets/postgres_password
     # DSNs are built in worker entrypoint from user + pw files
     QDRANT_URL: http://qdrant:6333
@@ -214,6 +217,11 @@ services:
     depends_on: [postgres, redis, qdrant]
     environment:
       <<: *env
+      # Cap glibc malloc arenas: with the default (8 × cores) freed transient
+      # search working sets scatter across arenas and never return to the OS,
+      # so RSS ratchets to the historical peak (#96). 2 arenas is the standard
+      # server setting; contention is negligible on a single uvicorn worker.
+      MALLOC_ARENA_MAX: 2
       POSTGRES_PASSWORD_FILE: /run/secrets/postgres_password
       QDRANT_URL: http://qdrant:6333
       SERVER_URL: "${SERVER_URL:-http://localhost:8000}"

--- a/requirements/requirements-api.txt
+++ b/requirements/requirements-api.txt
@@ -6,8 +6,14 @@ fastapi>=0.115.12
 # [standard] includes websockets support.
 uvicorn[standard]>=0.34,<1.0
 python-multipart==0.0.9
-mcp==1.10.0
-fastmcp>=2.10.0
+# mcp must stay >=1.12 — earlier versions leak one server session per
+# stateless HTTP request (no transport.terminate() in
+# _handle_stateless_request), ratcheting api-container RSS to its limit (#96).
+# fastmcp is pinned exactly because its minor releases break APIs and add
+# heavy deps (2.14 requires fakeredis, conflicting with our dev pin); it pins
+# a narrow mcp range, so bump both together.
+mcp==1.22.0
+fastmcp==2.13.3
 slowapi==0.1.9
 cachetools>=5.3.0  # TTL-based caching for prediction market tools
 jinja2>=3.1.0  # Required by starlette Jinja2Templates (MCP OAuth login page)

--- a/requirements/requirements-api.txt
+++ b/requirements/requirements-api.txt
@@ -9,9 +9,10 @@ python-multipart==0.0.9
 # mcp must stay >=1.12 — earlier versions leak one server session per
 # stateless HTTP request (no transport.terminate() in
 # _handle_stateless_request), ratcheting api-container RSS to its limit (#96).
-# fastmcp is pinned exactly because its minor releases break APIs and add
-# heavy deps (2.14 requires fakeredis, conflicting with our dev pin); it pins
-# a narrow mcp range, so bump both together.
+# fastmcp is pinned exactly because its minor releases break APIs and pin
+# narrow mcp ranges (2.14 needs mcp>=1.23.1, untested here; 2.14.7 also adds
+# a runtime fakeredis<2.35 dep that conflicts with our dev fakeredis pin).
+# Bump both together.
 mcp==1.22.0
 fastmcp==2.13.3
 slowapi==0.1.9

--- a/requirements/requirements-common.txt
+++ b/requirements/requirements-common.txt
@@ -7,7 +7,7 @@ voyageai==0.3.2
 qdrant-client==1.9.0
 anthropic==0.69.0
 openai==2.3.0
-# Updated for fastmcp>=2.10 compatibility (anthropic 0.69.0 supports httpx<1)
+# httpx floor required by fastmcp; anthropic 0.69.0 tolerates httpx<1
 httpx>=0.28.1
 celery[redis,sqs]==5.3.6
 croniter==2.0.1

--- a/src/memory/api/MCP/oauth_provider.py
+++ b/src/memory/api/MCP/oauth_provider.py
@@ -11,7 +11,6 @@ from urllib.parse import parse_qs, urlencode, urlparse, urlunparse
 from fastmcp.server.auth import OAuthProvider
 from fastmcp.server.auth.auth import AccessToken as FastMCPAccessToken  # type: ignore[reportPrivateImportUsage]
 from mcp.server.auth.provider import (
-    AccessToken,
     AuthorizationCode,
     AuthorizationParams,
     RefreshToken,
@@ -607,7 +606,7 @@ class SimpleOAuthProvider(OAuthProvider):
             )
         else:
             allowed_origins = {redirect_uri_origin(p) for p in allowlist}
-            for uri in client_info.redirect_uris:
+            for uri in client_info.redirect_uris or []:
                 uri_str = str(uri)
                 if not is_redirect_uri_allowed(
                     redirect_uri_origin(uri_str), allowed_origins
@@ -941,14 +940,13 @@ class SimpleOAuthProvider(OAuthProvider):
 
             return token
 
-    async def load_access_token(self, token: str) -> Optional[AccessToken]:
+    async def load_access_token(self, token: str) -> Optional[FastMCPAccessToken]:
         """Load and validate an access token (or bot API key).
 
         Companion to :meth:`verify_token`; both share lookup + expiry +
         one-time-key consumption via :func:`lookup_principal`. This
         method differs only in projecting OAuth-grant scopes (via
-        :func:`resolve_session_scopes`) instead of system scopes, and
-        returning an ``AccessToken`` rather than ``FastMCPAccessToken``.
+        :func:`resolve_session_scopes`) instead of system scopes.
         """
         with make_session() as session:
             principal = lookup_principal(token, session)
@@ -962,7 +960,7 @@ class SimpleOAuthProvider(OAuthProvider):
                 client_id, scopes = resolve_session_scopes(
                     principal.user_session
                 )
-                return AccessToken(
+                return FastMCPAccessToken(
                     token=token,
                     client_id=client_id,
                     scopes=scopes,
@@ -981,7 +979,7 @@ class SimpleOAuthProvider(OAuthProvider):
                 f"User {principal.user.name} (id={principal.user.id}) "
                 f"authenticated via API key"
             )
-            return AccessToken(
+            return FastMCPAccessToken(
                 token=token,
                 client_id=cast(
                     str, principal.user.name or principal.user.email
@@ -994,6 +992,11 @@ class SimpleOAuthProvider(OAuthProvider):
         self, client: OAuthClientInformationFull, refresh_token: str
     ) -> Optional[RefreshToken]:
         """Load and validate a refresh token."""
+        # client_id is optional on OAuthClientInformationFull (URL-based
+        # client IDs may omit it); a client without one has no tokens.
+        if client.client_id is None:
+            return None
+
         with make_session() as session:
             now = now_naive_utc()
 

--- a/src/memory/api/MCP/visibility_middleware.py
+++ b/src/memory/api/MCP/visibility_middleware.py
@@ -13,7 +13,7 @@ A user can access a tool if:
 """
 
 import logging
-from collections.abc import Callable
+from collections.abc import Callable, Sequence
 
 import mcp.types as mt
 from fastmcp.server.middleware import CallNext, Middleware, MiddlewareContext
@@ -106,8 +106,8 @@ class VisibilityMiddleware(Middleware):
     async def on_list_tools(
         self,
         context: MiddlewareContext[mt.ListToolsRequest],
-        call_next: CallNext[mt.ListToolsRequest, list[Tool]],
-    ) -> list[Tool]:
+        call_next: CallNext[mt.ListToolsRequest, Sequence[Tool]],
+    ) -> Sequence[Tool]:
         """Filter tool list to only show tools the user can access."""
         tools = await call_next(context)
         user_info = self.get_user_info()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -555,9 +555,9 @@ def mcp_auth_context(session_token: str, scopes: list[str] | None = None):
         with mcp_auth_context(admin_session.id):
             result = await some_mcp_tool(...)
     """
+    from fastmcp.server.auth.auth import AccessToken  # type: ignore[reportPrivateImportUsage]
     from mcp.server.auth.middleware.auth_context import auth_context_var
     from mcp.server.auth.middleware.bearer_auth import AuthenticatedUser
-    from mcp.server.auth.provider import AccessToken
     from memory.common.db.connection import make_session
     from memory.common.db.models import UserSession
 
@@ -571,6 +571,9 @@ def mcp_auth_context(session_token: str, scopes: list[str] | None = None):
             else:
                 scopes = []
 
+    # fastmcp's AccessToken (what verify_token returns in production), not the
+    # bare SDK one: fastmcp's get_access_token() converts foreign token types
+    # with claims=None, which its own model rejects.
     access_token = AccessToken(
         token=session_token,
         client_id="test-client",

--- a/tests/memory/api/MCP/test_meta.py
+++ b/tests/memory/api/MCP/test_meta.py
@@ -457,9 +457,9 @@ def _mcp_auth_context_with_scopes(session_token: str, scopes: list[str]):
     access token reflects only the scopes the user consented to at the OAuth
     consent screen.
     """
+    from fastmcp.server.auth.auth import AccessToken  # type: ignore[reportPrivateImportUsage]
     from mcp.server.auth.middleware.auth_context import auth_context_var
     from mcp.server.auth.middleware.bearer_auth import AuthenticatedUser
-    from mcp.server.auth.provider import AccessToken
 
     access_token = AccessToken(
         token=session_token,

--- a/tests/memory/api/MCP/test_teams.py
+++ b/tests/memory/api/MCP/test_teams.py
@@ -6,9 +6,9 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 from sqlalchemy.orm import selectinload
+from fastmcp.server.auth.auth import AccessToken  # type: ignore[reportPrivateImportUsage]
 from mcp.server.auth.middleware.auth_context import auth_context_var
 from mcp.server.auth.middleware.bearer_auth import AuthenticatedUser
-from mcp.server.auth.provider import AccessToken
 
 from memory.common.db.models import (
     DiscordUser,


### PR DESCRIPTION
## Summary

Fixes the primary root cause of #96: the `api` container's RSS ratcheting from ~264MB to its 1GiB limit over ~5 days.

- **Upgrade `mcp` 1.10.0 → 1.22.0** — mcp ≤1.11 never calls `http_transport.terminate()` in `_handle_stateless_request`, so every `POST /mcp` leaks a live anyio task + ServerSession + memory streams for the life of the process (~1,150/day in prod). The upstream fix (terminate after `handle_request`) landed in mcp 1.12.0; verified present in 1.22.0.
- **Pin `fastmcp==2.13.3`** (was floating `>=2.10.0`) — newest 2.x line that avoids fastmcp 2.14's runtime `fakeredis<2.35` dependency (conflicts with our dev pin `fakeredis==2.36.0`) and pins a narrow compatible mcp range. Pinned exactly since fastmcp minors break APIs; the requirements comment says to bump both together.
- **`MALLOC_ARENA_MAX=2`** on the api and worker containers — freed transient search/ingest working sets otherwise scatter across up to 32 glibc arenas and never return to the OS, pinning RSS at its historical peak (root cause 2 in the issue).

## Test fallout

fastmcp ≥2.13's `get_access_token()` converts foreign token types with `claims=None`, which its own model rejects. The test auth helpers (`conftest.py` `mcp_auth_context` + local copies in `test_teams.py`/`test_meta.py`) now build fastmcp's `AccessToken` — the same type `verify_token` returns in production — instead of the bare SDK one.

## Verification

- MCP test suite: **1167 passed, 0 failed** against the new pins (was 279 failures before the harness fix, all one root cause).
- Full non-qdrant suite: 5307 passed; the 12 remaining failures reproduce identically on the old pins (known sandbox qdrant gap).
- `pip install --dry-run` resolves `.[api]` and `.[all]` cleanly; redis stays 5.3.1.
- Installed mcp 1.22.0 `_handle_stateless_request` confirmed to terminate the transport.

Post-deploy check (from the issue): RSS curve should flatten at ~300MB instead of creeping ~7MB/h; optionally verify `len(asyncio.all_tasks())` stays in the dozens.

Remaining #96 items (payload-free candidate search, client caching, per-service metrics, MCP user_id attribution, oauth_client reaper) are intentionally out of scope.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TD6Ef83TfvdqxyczzCKpCA