### PR TITLE
feat(sessions): search over archived Claude session transcripts

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -95,6 +95,7 @@ The parser turns raw content into items; the Celery task module drives ingestion
 | Forum posts | `parsers/lesswrong.py` | `workers/tasks/forums.py` | `forums` |
 | Notes | — | `workers/tasks/notes.py` | `notes` |
 | Photos/Images | — | `workers/tasks/photo.py` | `photos` |
+| Claude sessions | `parsers/claude_sessions.py` | `workers/tasks/sessions.py` | `maintenance` |
 
 Full queue list: the worker `QUEUES` env var in `docker-compose.yaml`.
 

--- a/db/migrations/versions/20260702_session_segments.py
+++ b/db/migrations/versions/20260702_session_segments.py
@@ -1,0 +1,76 @@
+"""Session transcript search: session_segment table + indexing watermark.
+
+SessionSegments are SourceItem subtypes holding embedding-sized runs of
+conversational messages from Claude Code session transcripts, so archived
+sessions become searchable (issue #100). The sessions table gains the
+indexing watermark columns the indexer uses to process only new lines.
+
+Revision ID: 20260702_session_segments
+Revises: 20260620_github_author_person
+Create Date: 2026-07-02
+"""
+
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy.dialects import postgresql
+
+
+# alembic_version.version_num is varchar(32); keep this id ≤32 chars.
+revision: str = "20260702_session_segments"
+down_revision: Union[str, None] = "20260620_github_author_person"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "session_segment",
+        sa.Column(
+            "id",
+            sa.BigInteger(),
+            sa.ForeignKey("source_item.id", ondelete="CASCADE"),
+            primary_key=True,
+        ),
+        sa.Column(
+            "session_id",
+            postgresql.UUID(as_uuid=True),
+            sa.ForeignKey("sessions.id", ondelete="CASCADE"),
+            nullable=False,
+        ),
+        sa.Column("start_index", sa.Integer(), nullable=False),
+        sa.Column("end_index", sa.Integer(), nullable=False),
+        sa.Column("start_time", sa.DateTime(timezone=True), nullable=True),
+        sa.Column("end_time", sa.DateTime(timezone=True), nullable=True),
+        sa.Column(
+            "roles", postgresql.ARRAY(sa.Text()), nullable=False, server_default="{}"
+        ),
+        sa.Column(
+            "models", postgresql.ARRAY(sa.Text()), nullable=False, server_default="{}"
+        ),
+    )
+    op.create_index(
+        "session_segment_session_idx",
+        "session_segment",
+        ["session_id", "start_index"],
+        unique=True,
+    )
+    op.create_index("session_segment_time_idx", "session_segment", ["start_time"])
+
+    op.add_column(
+        "sessions",
+        sa.Column("indexed_up_to", sa.Integer(), nullable=False, server_default="0"),
+    )
+    op.add_column(
+        "sessions",
+        sa.Column("indexed_at", sa.DateTime(timezone=True), nullable=True),
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("sessions", "indexed_at")
+    op.drop_column("sessions", "indexed_up_to")
+    op.drop_index("session_segment_time_idx", table_name="session_segment")
+    op.drop_index("session_segment_session_idx", table_name="session_segment")
+    op.drop_table("session_segment")

--- a/src/memory/api/MCP/servers/claude.py
+++ b/src/memory/api/MCP/servers/claude.py
@@ -1,18 +1,35 @@
-"""MCP subserver for cloud-claude session file transfer.
+"""MCP subserver for Claude Code sessions.
 
-Tools here orchestrate file transfer between the user's local machine and a
-remote claude-cloud session container. Bytes don't flow through MCP; instead
-these tools mint short-lived signed URLs that a bundled bash script (in the
-session-files skill) can curl directly. This sidesteps MCP payload caps and
-gives natural streaming for arbitrary file types and folders.
+Two tool families live here:
+
+- Cloud-container file transfer (``session_list``/``session_list_dir``/
+  ``session_pull_url``/``session_push_url``): orchestrate file transfer
+  between the user's local machine and a remote claude-cloud session
+  container. Bytes don't flow through MCP; these tools mint short-lived
+  signed URLs that a bundled bash script (in the session-files skill) can
+  curl directly, sidestepping MCP payload caps.
+
+- Archived-transcript search (``session_search``/``session_fetch``): query
+  the stored JSONL transcripts of past Claude Code sessions. Strictly
+  owner-only — sessions are personal working data, so even admins only see
+  their own here.
 """
 
 import logging
+from collections import deque
+from datetime import datetime
 from typing import Any
+from uuid import UUID as PyUUID
 
 from fastmcp import FastMCP
+from sqlalchemy import or_
+from sqlalchemy.orm import joinedload
 
-from memory.api.MCP.access import get_mcp_current_user
+from memory.api.MCP.access import (
+    build_user_access_filter_from_dict,
+    get_mcp_current_user,
+    log_search_access,
+)
 from memory.api.MCP.visibility import require_scopes, visible_when
 from memory.api.cloud_claude import (
     get_user_id_from_session,
@@ -22,17 +39,30 @@ from memory.api.orchestrator_client import (
     OrchestratorError,
     get_orchestrator_client,
 )
+from memory.api.search.search import search as search_base
+from memory.api.search.types import SearchConfig, SearchFilters
 from memory.api.transfer_tokens import (
     mint_transfer_url,
     normalize_abs_path,
     validate_transfer_path,
 )
-from memory.common import settings
+from memory.common import extract, settings
+from memory.common.dates import parse_iso_datetime_utc
+from memory.common.db.connection import make_session
+from memory.common.db.models import CodingProject, Session, SessionSegment
 from memory.common.scopes import SCOPE_READ, SCOPE_WRITE
+from memory.parsers import claude_sessions
 
 logger = logging.getLogger(__name__)
 
+MAX_FETCH_MESSAGES = 100
+
 claude_mcp = FastMCP("memory-claude")
+
+
+def like_escape(value: str) -> str:
+    """Backslash-escape LIKE metacharacters (%, _, \\) for use in a pattern."""
+    return value.replace("\\", "\\\\").replace("%", "\\%").replace("_", "\\_")
 
 
 def user_owns(user_id: int, session_id: str) -> bool:
@@ -228,3 +258,279 @@ async def session_push_url(
         raise ValueError("Session not found")
 
     return mint_for("write", user.id, sid, path)
+
+
+# --- Archived transcript search -------------------------------------------
+
+
+def owned_segment_ids(
+    user_id: int,
+    project: str | None = None,
+    start_time: datetime | None = None,
+    end_time: datetime | None = None,
+    role: str | None = None,
+) -> list[int]:
+    """IDs of SessionSegments owned by ``user_id`` matching the filters.
+
+    This is the owner-only gate for transcript search: passing the result
+    as ``source_ids`` restricts the whole hybrid pipeline (Qdrant + BM25)
+    to the caller's own sessions, on top of the regular access filter.
+    """
+    with make_session() as db:
+        query = (
+            db.query(SessionSegment.id)
+            .join(Session, SessionSegment.session_id == Session.id)
+            .filter(Session.user_id == user_id)
+        )
+        if project:
+            query = query.join(
+                CodingProject, Session.coding_project_id == CodingProject.id
+            ).filter(
+                CodingProject.directory.ilike(
+                    f"%{like_escape(project)}%", escape="\\"
+                )
+            )
+        # Timestamp-less segments (transcripts whose events carry no
+        # timestamps) match any date range rather than silently vanishing.
+        if start_time:
+            query = query.filter(
+                or_(
+                    SessionSegment.end_time >= start_time,
+                    SessionSegment.end_time.is_(None),
+                )
+            )
+        if end_time:
+            query = query.filter(
+                or_(
+                    SessionSegment.start_time <= end_time,
+                    SessionSegment.start_time.is_(None),
+                )
+            )
+        if role:
+            query = query.filter(SessionSegment.roles.contains([role]))
+        return [row[0] for row in query.all()]
+
+
+def parse_time_arg(value: str | None, name: str) -> datetime | None:
+    if not value:
+        return None
+    parsed = parse_iso_datetime_utc(value)
+    if parsed is None:
+        raise ValueError(f"Invalid {name}: {value!r} (expected ISO format)")
+    return parsed
+
+
+@claude_mcp.tool()
+@visible_when(require_scopes(SCOPE_READ))
+async def session_search(
+    query: str,
+    project: str | None = None,
+    start_date: str | None = None,
+    end_date: str | None = None,
+    role: str | None = None,
+    limit: int = 10,
+) -> list[dict[str, Any]]:
+    """Search your archived Claude Code session transcripts.
+
+    Hybrid semantic + keyword search over the conversational text of past
+    sessions (tool traffic is not indexed). Only your own sessions are
+    searched. Each hit points into one session's transcript; use
+    session_fetch with the hit's session_id and start_index to read the
+    surrounding conversation.
+
+    Args:
+        query: Natural language description of what you're looking for.
+        project: Substring match on the project directory (e.g. "memory").
+        start_date: Only match segments ending at/after this ISO timestamp.
+        end_date: Only match segments starting at/before this ISO timestamp.
+        role: Only match segments containing this role: "user" or "assistant".
+        limit: Maximum hits to return (default 10, max 50).
+
+    Returns:
+        Hits sorted by relevance, each with session_id, project directory,
+        session_summary, start_index/end_index (transcript line range),
+        start_time/end_time, roles, models, score, and a text snippet.
+    """
+    user = get_mcp_current_user()
+    if not user or user.id is None:
+        raise ValueError("Not authenticated")
+
+    start_time = parse_time_arg(start_date, "start_date")
+    end_time = parse_time_arg(end_date, "end_date")
+
+    source_ids = owned_segment_ids(user.id, project, start_time, end_time, role)
+    if not source_ids:
+        return []
+
+    filters = SearchFilters(
+        source_ids=source_ids,
+        access_filter=build_user_access_filter_from_dict(
+            {"id": user.id, "scopes": user.scopes}
+        ),
+    )
+    # Transcript search should stay cheap/local: no LLM round-trips for HyDE
+    # or query analysis — the BM25 + embedding hybrid still applies.
+    config = SearchConfig(
+        limit=max(1, min(limit, 50)), useHyde=False, useQueryAnalysis=False
+    )
+    results = await search_base(
+        extract.extract_text(query, skip_summary=True),
+        modalities={"session"},
+        filters=filters,
+        config=config,
+    )
+
+    session_ids = {
+        meta["session_id"]
+        for r in results
+        if (meta := r.metadata) and meta.get("session_id")
+    }
+    with make_session() as db:
+        sessions = (
+            db.query(Session)
+            .options(joinedload(Session.coding_project))
+            .filter(Session.id.in_([PyUUID(sid) for sid in session_ids]))
+            .all()
+        )
+        sessions_by_id = {
+            str(s.id): {
+                "project": s.coding_project.directory if s.coding_project else None,
+                "summary": s.summary,
+            }
+            for s in sessions
+        }
+
+    hits = []
+    for r in results:
+        meta = r.metadata or {}
+        session_info = sessions_by_id.get(meta.get("session_id") or "", {})
+        snippet = (r.chunks[0] if r.chunks else r.content) or ""
+        hits.append(
+            {
+                "session_id": meta.get("session_id"),
+                "project": session_info.get("project"),
+                "session_summary": session_info.get("summary"),
+                "start_index": meta.get("start_index"),
+                "end_index": meta.get("end_index"),
+                "start_time": meta.get("start_time"),
+                "end_time": meta.get("end_time"),
+                "roles": meta.get("roles"),
+                "models": meta.get("models"),
+                "score": r.search_score,
+                "snippet": str(snippet)[:500],
+            }
+        )
+
+    try:
+        log_search_access(user.id, query, len(hits))
+    except Exception:
+        logger.exception("log_search_access failed for user_id=%s", user.id)
+
+    return hits
+
+
+def window_around_time(
+    file, target: datetime, limit: int
+) -> list[claude_sessions.TranscriptMessage]:
+    """A window of up to ``limit`` messages centered on ``target``.
+
+    Streams the transcript once: keeps the last limit//2 messages before
+    the first message at/after ``target``, then fills the rest of the
+    window going forward.
+    """
+    before: deque[claude_sessions.TranscriptMessage] = deque(maxlen=limit // 2)
+    after: list[claude_sessions.TranscriptMessage] = []
+    pivot_seen = False
+
+    for message in claude_sessions.iter_transcript_messages(file):
+        if not pivot_seen and message.timestamp and message.timestamp >= target:
+            pivot_seen = True
+        if pivot_seen:
+            after.append(message)
+            if len(after) >= limit - len(before):
+                break
+        else:
+            before.append(message)
+
+    return list(before) + after
+
+
+@claude_mcp.tool()
+@visible_when(require_scopes(SCOPE_READ))
+async def session_fetch(
+    session_id: str,
+    start_index: int = 0,
+    around_time: str | None = None,
+    limit: int = 20,
+) -> dict[str, Any]:
+    """Read conversational messages from one of your archived session transcripts.
+
+    Returns an ordered window of user/assistant messages (tool traffic is
+    omitted; individual messages are truncated to ~5000 chars). Use after
+    session_search to read the context around a hit, or to page through a
+    session from the start.
+
+    Args:
+        session_id: Session UUID (from session_search or the sessions API).
+        start_index: Transcript line index to start from (a hit's
+            start_index, or a previous call's next_index).
+        around_time: ISO timestamp; returns a window centered on it
+            (overrides start_index).
+        limit: Maximum messages to return (default 20, max 100).
+
+    Returns:
+        {session_id, project, summary, messages: [{index, role, timestamp,
+        model, text}], next_index} — next_index is null once the transcript
+        is exhausted.
+    """
+    user = get_mcp_current_user()
+    if not user or user.id is None:
+        raise ValueError("Not authenticated")
+
+    try:
+        session_uuid = PyUUID(session_id)
+    except ValueError:
+        raise ValueError(f"Invalid session UUID: {session_id}")
+
+    with make_session() as db:
+        session = db.get(Session, session_uuid)
+        if not session or session.user_id != user.id:
+            raise ValueError("Session not found")
+        transcript_path = session.transcript_path
+        summary = session.summary
+        project = session.coding_project.directory if session.coding_project else None
+
+    limit = max(1, min(limit, MAX_FETCH_MESSAGES))
+    messages: list[claude_sessions.TranscriptMessage] = []
+
+    transcript_file = (
+        settings.SESSIONS_STORAGE_DIR / transcript_path if transcript_path else None
+    )
+    if transcript_file and transcript_file.exists():
+        if target := parse_time_arg(around_time, "around_time"):
+            messages = window_around_time(transcript_file, target, limit)
+        else:
+            iterator = claude_sessions.iter_transcript_messages(
+                transcript_file, start_index=max(0, start_index)
+            )
+            for message in iterator:
+                messages.append(message)
+                if len(messages) >= limit:
+                    break
+
+    return {
+        "session_id": session_id,
+        "project": project,
+        "summary": summary,
+        "messages": [
+            {
+                "index": m.index,
+                "role": m.role,
+                "timestamp": m.timestamp.isoformat() if m.timestamp else None,
+                "model": m.model,
+                "text": m.text,
+            }
+            for m in messages
+        ],
+        "next_index": messages[-1].index + 1 if len(messages) >= limit else None,
+    }

--- a/src/memory/api/MCP/servers/core.py
+++ b/src/memory/api/MCP/servers/core.py
@@ -46,7 +46,11 @@ from memory.api.search.types import MCPSearchFilters, SearchConfig, SearchFilter
 from memory.common import extract, paths, settings
 from memory.common.celery_app import SYNC_OBSERVATION
 from memory.common.celery_app import app as celery_app
-from memory.common.collections import ALL_COLLECTIONS, OBSERVATION_COLLECTIONS
+from memory.common.collections import (
+    ALL_COLLECTIONS,
+    OBSERVATION_COLLECTIONS,
+    SESSION_COLLECTIONS,
+)
 from memory.common.db.connection import make_session
 from memory.common.db.models import (
     AgentObservation,
@@ -153,7 +157,7 @@ SEARCH_FILTERS: list[tuple[str, str, str | None]] = [
 
 def _get_available_modalities() -> list[str]:
     """Query database to find which modalities have indexed items."""
-    searchable = set(ALL_COLLECTIONS.keys()) - OBSERVATION_COLLECTIONS
+    searchable = set(ALL_COLLECTIONS.keys()) - OBSERVATION_COLLECTIONS - SESSION_COLLECTIONS
     try:
         with make_session() as session:
             from sqlalchemy import func as sql_func
@@ -335,7 +339,14 @@ async def search(
 
     if not modalities:
         modalities = set(ALL_COLLECTIONS.keys())
-    modalities = (set(modalities) & ALL_COLLECTIONS.keys()) - OBSERVATION_COLLECTIONS
+    # Observations and session transcripts have dedicated tools
+    # (search_observations, claude_session_search) with their own access
+    # semantics — generic search never touches them.
+    modalities = (
+        (set(modalities) & ALL_COLLECTIONS.keys())
+        - OBSERVATION_COLLECTIONS
+        - SESSION_COLLECTIONS
+    )
 
     search_filters = SearchFilters(**filters)
     search_filters["source_ids"] = filter_source_ids(modalities, search_filters)
@@ -704,6 +715,9 @@ async def fetch(
                 session.query(SourceItem)
                 .options(selectinload(SourceItem.people))
                 .filter(SourceItem.embed_status == "STORED")
+                # Session transcripts are owner-only-even-for-admins;
+                # only claude_session_fetch may read them.
+                .filter(SourceItem.modality.notin_(SESSION_COLLECTIONS))
             )
             items = fetch_accessible_source_items(
                 session, fetch_ids, access_filter, base_query=base_query
@@ -826,6 +840,13 @@ def apply_item_filters(query, modalities: set[str], filters: MCPSearchFilters):
     ValueError instead of being silently dropped.
     """
     reject_unknown_filter_keys(filters, allowed=ITEM_ALLOWED_FILTER_KEYS)
+
+    # Session transcripts are owner-only-even-for-admins by contract
+    # (claude_session_search/_fetch enforce ownership); the generic
+    # enumeration tools never expose them — an admin's access_filter is
+    # None, so without this exclusion list_items would return other
+    # users' private conversations.
+    query = query.filter(SourceItem.modality.notin_(SESSION_COLLECTIONS))
 
     if modalities:
         query = query.filter(SourceItem.modality.in_(modalities))

--- a/src/memory/api/MCP/servers/meta.py
+++ b/src/memory/api/MCP/servers/meta.py
@@ -9,6 +9,7 @@ from fastmcp import FastMCP
 from fastmcp.server.dependencies import get_access_token
 from memory.api.MCP.visibility import require_scopes, visible_when
 from memory.common import qdrant
+from memory.common.collections import SESSION_COLLECTIONS
 from memory.common.dates import parse_iso_datetime
 from memory.common.celery_app import SEND_NOTIFICATION
 from memory.common.celery_app import app as celery_app
@@ -277,7 +278,10 @@ async def get_metadata_schemas() -> dict[str, CollectionMetadata]:
     return {
         collection: CollectionMetadata(schema=schema, size=size)
         for collection, schema in schemas.items()
-        if (size := sizes.get(collection))
+        # Session transcripts are owner-only-even-for-admins and only
+        # reachable via claude_session_search; don't advertise their
+        # schema or the cross-user point count here.
+        if collection not in SESSION_COLLECTIONS and (size := sizes.get(collection))
     }
 
 

--- a/src/memory/common/celery_app.py
+++ b/src/memory/common/celery_app.py
@@ -155,6 +155,8 @@ RECONCILE_ACCESS_CONTROL = f"{MAINTENANCE_ROOT}.reconcile_access_control"
 SESSIONS_ROOT = "memory.workers.tasks.sessions"
 SUMMARIZE_SESSION = f"{SESSIONS_ROOT}.summarize_session"
 SUMMARIZE_STALE_SESSIONS = f"{SESSIONS_ROOT}.summarize_stale_sessions"
+INDEX_SESSION = f"{SESSIONS_ROOT}.index_session"
+INDEX_STALE_SESSIONS = f"{SESSIONS_ROOT}.index_stale_sessions"
 
 # Custom tasks (deployment-specific, loaded from CUSTOM_TASKS_DIR)
 CUSTOM_TASKS_PREFIX = "custom_tasks"
@@ -460,6 +462,10 @@ def build_beat_schedule() -> dict:
         "summarize-stale-sessions": {
             "task": SUMMARIZE_STALE_SESSIONS,
             "schedule": crontab(minute="30"),
+        },
+        "index-stale-sessions": {
+            "task": INDEX_STALE_SESSIONS,
+            "schedule": crontab(minute="50"),
         },
     }
     if settings.LESSWRONG_SYNC_INTERVAL > 0:

--- a/src/memory/common/collections.py
+++ b/src/memory/common/collections.py
@@ -131,6 +131,14 @@ ALL_COLLECTIONS: dict[str, Collection] = {
         "text": True,
         "multimodal": False,
     },
+    # Claude Code session transcripts (owner-only; searched via the
+    # dedicated claude_session_search MCP tool, not generic search)
+    "session": {
+        "dimension": 1024,
+        "distance": "Cosine",
+        "text": True,
+        "multimodal": False,
+    },
 }
 TEXT_COLLECTIONS = {
     coll for coll, params in ALL_COLLECTIONS.items() if params.get("text")
@@ -139,6 +147,7 @@ MULTIMODAL_COLLECTIONS = {
     coll for coll, params in ALL_COLLECTIONS.items() if params.get("multimodal")
 }
 OBSERVATION_COLLECTIONS = {"semantic", "temporal"}
+SESSION_COLLECTIONS = {"session"}
 
 TYPES = {
     "doc": ["application/pdf", "application/docx", "application/msword"],

--- a/src/memory/common/db/models/__init__.py
+++ b/src/memory/common/db/models/__init__.py
@@ -40,6 +40,8 @@ from memory.common.db.models.source_items import (
     CalendarEventPayload,
     MeetingPayload,
     Meeting,
+    SessionSegment,
+    SessionSegmentPayload,
     ReportPayload,
 )
 from memory.common.db.models.discord import (
@@ -226,6 +228,8 @@ __all__ = [
     "CalendarEventPayload",
     "Meeting",
     "MeetingPayload",
+    "SessionSegment",
+    "SessionSegmentPayload",
     "Report",
     "ReportPayload",
     # Observations

--- a/src/memory/common/db/models/sessions.py
+++ b/src/memory/common/db/models/sessions.py
@@ -15,6 +15,7 @@ from sqlalchemy import (
     DateTime,
     ForeignKey,
     Index,
+    Integer,
     String,
     Text,
     UniqueConstraint,
@@ -167,6 +168,14 @@ class Session(Base):
     # AI-generated summary of what was done in this session
     summary: Mapped[str | None] = mapped_column(Text, nullable=True)
     summary_updated_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)
+
+    # Search-indexing watermark: transcript line index up to which
+    # SessionSegments have been created (exclusive), and when the indexer
+    # last ran. See memory.workers.tasks.sessions.index_session.
+    indexed_up_to: Mapped[int] = mapped_column(
+        Integer, nullable=False, default=0, server_default="0"
+    )
+    indexed_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)
 
     __table_args__ = (
         Index("idx_sessions_user", "user_id"),

--- a/src/memory/common/db/models/source_items.py
+++ b/src/memory/common/db/models/source_items.py
@@ -27,8 +27,10 @@ from sqlalchemy import (
     Text,
     func,
 )
-from sqlalchemy.dialects.postgresql import JSONB, TSVECTOR
+from sqlalchemy.dialects import postgresql
+from sqlalchemy.dialects.postgresql import JSONB, TSVECTOR, UUID
 from sqlalchemy.orm import Mapped, mapped_column, relationship
+from uuid import UUID as PyUUID
 
 from memory.common import paths, settings
 import memory.common.extract as extract
@@ -64,6 +66,7 @@ if TYPE_CHECKING:
         TranscriptAccount,
     )
     from memory.common.db.models.observations import ObservationContradiction
+    from memory.common.db.models.sessions import Session
 
 
 def mail_addresses(values: Sequence[str]) -> list[str]:
@@ -2107,3 +2110,94 @@ class Meeting(SourceItem):
     @classmethod
     def get_collections(cls) -> list[str]:
         return ["meeting"]
+
+
+class SessionSegmentPayload(SourceItemPayload):
+    session_id: Annotated[str, "UUID of the Claude Code session"]
+    start_index: Annotated[int, "Transcript line index of the first message (inclusive)"]
+    end_index: Annotated[int, "Transcript line index of the last message (inclusive)"]
+    start_time: Annotated[str | None, "Timestamp of the first message (ISO format)"]
+    end_time: Annotated[str | None, "Timestamp of the last message (ISO format)"]
+    roles: Annotated[list[str], "Roles present in the segment (user/assistant)"]
+    models: Annotated[list[str], "Assistant models seen in the segment"]
+
+
+class SessionSegment(SourceItem):
+    """A run of consecutive messages from a Claude Code session transcript.
+
+    Segments are the searchable unit for archived session transcripts:
+    conversational text only (tool traffic stripped), sized to roughly one
+    embedding chunk, with line indices pointing back into the JSONL file so
+    claude_session_fetch can pull the surrounding context.
+
+    Owner-only by construction: ``creator_id`` is the session owner and
+    ``project_id`` is an explicit NULL, so nobody but the creator (and
+    superadmins) can ever see a segment.
+    """
+
+    __tablename__ = "session_segment"
+
+    id: Mapped[int] = mapped_column(
+        BigInteger, ForeignKey("source_item.id", ondelete="CASCADE"), primary_key=True
+    )
+    session_id: Mapped[PyUUID] = mapped_column(
+        UUID(as_uuid=True),
+        ForeignKey("sessions.id", ondelete="CASCADE"),
+        nullable=False,
+    )
+    # Transcript line indices covered by this segment, both inclusive.
+    # Lines in between that aren't conversational (tool traffic, meta
+    # events) are simply not part of the segment text.
+    start_index: Mapped[int] = mapped_column(Integer, nullable=False)
+    end_index: Mapped[int] = mapped_column(Integer, nullable=False)
+    start_time: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)
+    end_time: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)
+    # postgresql.ARRAY (not the generic sqlalchemy.ARRAY) so the search
+    # prefilter can use .contains() for role filtering
+    roles: Mapped[list[str]] = mapped_column(
+        postgresql.ARRAY(Text), nullable=False, server_default="{}"
+    )
+    models: Mapped[list[str]] = mapped_column(
+        postgresql.ARRAY(Text), nullable=False, server_default="{}"
+    )
+
+    session: Mapped[Session] = relationship("Session", foreign_keys=[session_id])
+
+    __mapper_args__ = {
+        "polymorphic_identity": "session_segment",
+    }
+
+    __table_args__ = (
+        Index("session_segment_session_idx", "session_id", "start_index", unique=True),
+        Index("session_segment_time_idx", "start_time"),
+    )
+
+    def __init__(self, **kwargs: Any) -> None:
+        if not kwargs.get("modality"):
+            kwargs["modality"] = "session"
+        super().__init__(**kwargs)
+
+    def as_payload(self) -> SessionSegmentPayload:
+        return SessionSegmentPayload(
+            **super().as_payload(),
+            session_id=str(self.session_id),
+            start_index=self.start_index,
+            end_index=self.end_index,
+            start_time=(self.start_time and self.start_time.isoformat() or None),
+            end_time=(self.end_time and self.end_time.isoformat() or None),
+            roles=self.roles,
+            models=self.models,
+        )
+
+    @property
+    def title(self) -> str:
+        return f"Claude session {self.session_id} [{self.start_index}-{self.end_index}]"
+
+    def _chunk_contents(self) -> Sequence[extract.DataChunk]:
+        if not self.content:
+            return []
+        return extract.extract_text(self.content, modality="session", skip_summary=True)
+
+    @classmethod
+    def get_collections(cls) -> list[str]:
+        return ["session"]

--- a/src/memory/common/settings.py
+++ b/src/memory/common/settings.py
@@ -527,6 +527,12 @@ VERIFICATION_SYNC_INTERVAL = int(
 # Session retention settings
 SESSION_RETENTION_DAYS = int(os.getenv("SESSION_RETENTION_DAYS", 365 * 2))
 
+# How long a session transcript must be idle (no writes) before its trailing
+# partial segment is indexed for search. Complete segments are indexed
+# immediately; the tail is held back so a still-running session doesn't
+# produce overlapping segments as it grows.
+SESSION_INDEX_MIN_IDLE_SECONDS = int(os.getenv("SESSION_INDEX_MIN_IDLE_SECONDS", 3600))
+
 # SSH key encryption secret for encrypting private keys at rest
 # Generate with: python -c "import secrets; print(secrets.token_hex(32))"
 # This should be unique per deployment - if the same secret is used across

--- a/src/memory/parsers/claude_sessions.py
+++ b/src/memory/parsers/claude_sessions.py
@@ -1,0 +1,177 @@
+"""Parsing of Claude Code session transcripts (JSONL files).
+
+A transcript is one JSON event per line, as ingested by
+``memory.api.sessions``. This module extracts the conversational messages
+(user/assistant text, skipping tool traffic and meta events) and groups
+them into segments sized for embedding. Line indices are preserved so
+segments and search hits can point back into the transcript for
+context windows.
+"""
+
+import json
+import logging
+from collections.abc import Iterator
+from dataclasses import dataclass, field
+from datetime import datetime
+from pathlib import Path
+from typing import Any
+
+from memory.common import chunker, tokens
+from memory.common.dates import parse_iso_datetime_utc
+
+logger = logging.getLogger(__name__)
+
+# Individual messages longer than this are truncated before indexing —
+# pasted logs / file dumps would otherwise dominate a segment's embedding.
+MAX_MESSAGE_CHARS = 5000
+
+CONVERSATION_ROLES = ("user", "assistant")
+
+
+@dataclass
+class TranscriptMessage:
+    """One conversational message, tied back to its transcript line."""
+
+    index: int  # 0-based line index in the JSONL file
+    role: str  # "user" or "assistant"
+    text: str
+    timestamp: datetime | None = None
+    model: str | None = None  # assistant messages only
+
+    @property
+    def formatted(self) -> str:
+        return f"{self.role.capitalize()}: {self.text}"
+
+
+@dataclass
+class TranscriptSegment:
+    """A run of consecutive messages, sized to roughly one embedding chunk."""
+
+    messages: list[TranscriptMessage] = field(default_factory=list)
+
+    @property
+    def text(self) -> str:
+        return "\n\n".join(m.formatted for m in self.messages)
+
+    @property
+    def start_index(self) -> int:
+        return self.messages[0].index
+
+    @property
+    def end_index(self) -> int:
+        """Line index of the last message in the segment (inclusive)."""
+        return self.messages[-1].index
+
+    @property
+    def start_time(self) -> datetime | None:
+        return next((m.timestamp for m in self.messages if m.timestamp), None)
+
+    @property
+    def end_time(self) -> datetime | None:
+        return next(
+            (m.timestamp for m in reversed(self.messages) if m.timestamp), None
+        )
+
+    @property
+    def roles(self) -> list[str]:
+        return sorted({m.role for m in self.messages})
+
+    @property
+    def models(self) -> list[str]:
+        return sorted({m.model for m in self.messages if m.model})
+
+
+def extract_text_blocks(content: Any) -> str:
+    """Pull the human-readable text out of a message's content field.
+
+    Content is either a plain string or a list of typed blocks; only
+    ``text`` blocks count — tool_use, tool_result, and thinking blocks are
+    tool traffic, not conversation.
+    """
+    if isinstance(content, str):
+        return content.strip()
+    if not isinstance(content, list):
+        return ""
+    parts = [
+        block.get("text", "")
+        for block in content
+        if isinstance(block, dict) and block.get("type") == "text"
+    ]
+    return "\n".join(p for p in parts if p).strip()
+
+
+def parse_event(index: int, event: dict[str, Any]) -> TranscriptMessage | None:
+    """Convert one transcript event to a message, or None if it's not conversation."""
+    role = event.get("type")
+    if role not in CONVERSATION_ROLES or event.get("is_meta"):
+        return None
+
+    message = event.get("message") or {}
+    text = extract_text_blocks(message.get("content"))
+    if not text:
+        return None
+    if len(text) > MAX_MESSAGE_CHARS:
+        text = text[:MAX_MESSAGE_CHARS] + " [... truncated]"
+
+    return TranscriptMessage(
+        index=index,
+        role=role,
+        text=text,
+        timestamp=parse_iso_datetime_utc(event.get("timestamp")),
+        model=message.get("model") if role == "assistant" else None,
+    )
+
+
+def iter_transcript_messages(
+    file: Path, start_index: int = 0
+) -> Iterator[TranscriptMessage]:
+    """Stream conversational messages from a transcript file.
+
+    ``start_index`` skips lines before that index (the indexing watermark).
+    Blank and malformed lines still advance the line index so that indices
+    stay stable as the file grows.
+
+    Each call re-reads the file from the top, so reads are O(start_index):
+    fine at current transcript sizes, a conscious tradeoff over maintaining
+    a byte-offset index.
+    """
+    with open(file) as fh:
+        for i, line in enumerate(fh):
+            if i < start_index or not line.strip():
+                continue
+            try:
+                event = json.loads(line)
+            except json.JSONDecodeError:
+                continue
+            if message := parse_event(i, event):
+                yield message
+
+
+def build_segments(
+    messages: Iterator[TranscriptMessage] | list[TranscriptMessage],
+    max_tokens: int = chunker.DEFAULT_CHUNK_TOKENS,
+) -> list[TranscriptSegment]:
+    """Group consecutive messages into segments of at most ``max_tokens``.
+
+    Deterministic for a given message stream: re-running over the same
+    transcript prefix reproduces byte-identical segments, which is what
+    lets sha256 dedup make reindexing idempotent. A single message longer
+    than the budget gets its own segment (extract_text sub-chunks it at
+    embedding time).
+    """
+    segments: list[TranscriptSegment] = []
+    current = TranscriptSegment()
+    current_tokens = 0
+
+    for message in messages:
+        message_tokens = tokens.approx_token_count(message.formatted)
+        if current.messages and current_tokens + message_tokens > max_tokens:
+            segments.append(current)
+            current = TranscriptSegment()
+            current_tokens = 0
+        current.messages.append(message)
+        current_tokens += message_tokens
+
+    if current.messages:
+        segments.append(current)
+    return segments

--- a/src/memory/workers/tasks/maintenance.py
+++ b/src/memory/workers/tasks/maintenance.py
@@ -50,6 +50,7 @@ from memory.common.db.models.source_items import (
     GoogleDoc,
     MailMessage,
     Meeting,
+    SessionSegment,
     SlackMessage,
 )
 from memory.common.content_processing import (
@@ -640,6 +641,21 @@ def cleanup_old_claude_sessions(max_age_days: int | None = None):
             .filter(Session.started_at < cutoff)
             .all()
         )
+
+        # Delete search-index segments via their source_item parent rows.
+        # The sessions FK cascade would only remove the session_segment
+        # subtype rows, leaving orphaned source_item bases (and their
+        # chunks/vectors) behind. Deleting the parent rows cascades to
+        # segments and chunks; the clean-all-collections sweep then GCs
+        # the Qdrant points.
+        if old_sessions:
+            old_ids = [s.id for s in old_sessions]
+            segment_ids = select(SessionSegment.id).where(
+                SessionSegment.session_id.in_(old_ids)
+            )
+            db_session.query(SourceItem).filter(
+                SourceItem.id.in_(segment_ids)
+            ).delete(synchronize_session=False)
 
         for coding_session in old_sessions:
             # Delete transcript file if it exists

--- a/src/memory/workers/tasks/sessions.py
+++ b/src/memory/workers/tasks/sessions.py
@@ -1,23 +1,38 @@
 """
-Celery tasks for session summary generation.
+Celery tasks for session summary generation and search indexing.
 
 Provides scheduled tasks for:
 - Generating AI summaries of coding sessions
-- Updating session metadata
+- Indexing session transcripts for search (SessionSegment items)
 """
 
 import json
 import logging
 import os
 from datetime import datetime, timezone
+from pathlib import Path
 from uuid import UUID
 
+from sqlalchemy.exc import IntegrityError
+
 from memory.common import settings
-from memory.common.celery_app import app, SUMMARIZE_SESSION, SUMMARIZE_STALE_SESSIONS
+from memory.common.celery_app import (
+    app,
+    INDEX_SESSION,
+    INDEX_STALE_SESSIONS,
+    SUMMARIZE_SESSION,
+    SUMMARIZE_STALE_SESSIONS,
+)
+from memory.common.content_processing import (
+    check_content_exists,
+    create_content_hash,
+    process_content_item,
+)
 from memory.common.db.connection import make_session
-from memory.common.db.models import Session
+from memory.common.db.models import Session, SessionSegment
 from memory.common.jobs import tracked_task
 from memory.common.llms import create_provider, Message, MessageRole, LLMSettings
+from memory.parsers import claude_sessions
 
 logger = logging.getLogger(__name__)
 
@@ -242,3 +257,187 @@ def summarize_stale_sessions() -> dict:
         f"Session summarization check complete: {processed} queued, {skipped} skipped, {errors} errors"
     )
     return {"queued": processed, "skipped": skipped, "errors": errors}
+
+
+def transcript_idle(transcript_file: Path, now: datetime) -> bool:
+    """Whether the transcript has been quiet long enough to index its tail."""
+    mtime = datetime.fromtimestamp(transcript_file.stat().st_mtime, tz=timezone.utc)
+    return (now - mtime).total_seconds() >= settings.SESSION_INDEX_MIN_IDLE_SECONDS
+
+
+@app.task(name=INDEX_SESSION)
+@tracked_task
+def index_session(session_id: str) -> dict:
+    """
+    Create SessionSegment search items for a session's transcript.
+
+    Processes transcript lines past the session's ``indexed_up_to``
+    watermark, groups the conversational messages into embedding-sized
+    segments, and runs each through the standard content pipeline
+    (chunks + Qdrant + BM25). The trailing partial segment is held back
+    until the transcript has been idle for SESSION_INDEX_MIN_IDLE_SECONDS
+    so a still-running session doesn't produce overlapping segments.
+
+    Segments are owner-only: creator_id is the session owner and
+    project_id is an explicit NULL.
+    """
+    try:
+        session_uuid = UUID(session_id)
+    except ValueError:
+        logger.error(f"Invalid session UUID: {session_id}")
+        return {"status": "error", "message": "Invalid session UUID"}
+
+    now = datetime.now(timezone.utc)
+
+    with make_session() as db:
+        session = db.get(Session, session_uuid)
+        if not session:
+            return {"status": "error", "message": "Session not found"}
+        if not session.transcript_path:
+            return {"status": "skipped", "message": "No transcript"}
+
+        transcript_file = settings.SESSIONS_STORAGE_DIR / session.transcript_path
+        if not transcript_file.exists():
+            return {"status": "skipped", "message": "Transcript file missing"}
+
+        messages = claude_sessions.iter_transcript_messages(
+            transcript_file, start_index=session.indexed_up_to
+        )
+        segments = claude_sessions.build_segments(messages)
+
+        if segments and not transcript_idle(transcript_file, now):
+            segments = segments[:-1]
+
+        created, duplicates = 0, 0
+        failed_at: int | None = None
+        for segment in segments:
+            content = segment.text
+            sha256 = create_content_hash(
+                content, str(session.id), str(segment.start_index)
+            )
+            if check_content_exists(db, SessionSegment, sha256=sha256):
+                duplicates += 1
+            else:
+                item = SessionSegment(
+                    session_id=session.id,
+                    start_index=segment.start_index,
+                    end_index=segment.end_index,
+                    start_time=segment.start_time,
+                    end_time=segment.end_time,
+                    roles=segment.roles,
+                    models=segment.models,
+                    content=content,
+                    size=len(content),
+                    mime_type="text/plain",
+                    sha256=sha256,
+                    creator_id=session.user_id,
+                    project_id=None,  # explicit NULL: owner-only, never inherited
+                )
+                try:
+                    result = process_content_item(item, db)
+                except IntegrityError:
+                    # A concurrent index_session run inserted this segment
+                    # between our existence check and the flush; theirs is
+                    # identical (deterministic segmentation), so treat as
+                    # a duplicate and keep going.
+                    db.rollback()
+                    duplicates += 1
+                else:
+                    if result.get("status") == "failed":
+                        # Embedding failed (e.g. a transient Voyage outage).
+                        # Drop the FAILED row and halt the watermark here so
+                        # the hourly sweep retries this slice — advancing
+                        # past it would leave a permanent gap in the index,
+                        # since nothing re-embeds zero-chunk rows.
+                        db.delete(item)
+                        db.commit()
+                        failed_at = segment.start_index
+                        break
+                    created += 1
+            session.indexed_up_to = segment.end_index + 1
+
+        # Only mark the run complete on full success: a stale indexed_at
+        # keeps the sweep's requeue condition true, which is what retries
+        # the failed slice.
+        if failed_at is None:
+            session.indexed_at = now
+        db.commit()
+
+        if failed_at is not None:
+            logger.warning(
+                f"Indexing session {session_id} halted at segment {failed_at} "
+                f"(embedding failed); {created} segments created before halt"
+            )
+            return {
+                "status": "partial",
+                "created": created,
+                "duplicates": duplicates,
+                "failed_at": failed_at,
+                "indexed_up_to": session.indexed_up_to,
+            }
+
+        logger.info(
+            f"Indexed session {session_id}: {created} segments created, "
+            f"{duplicates} already present, watermark {session.indexed_up_to}"
+        )
+        return {
+            "status": "success",
+            "created": created,
+            "duplicates": duplicates,
+            "indexed_up_to": session.indexed_up_to,
+        }
+
+
+@app.task(name=INDEX_STALE_SESSIONS)
+@tracked_task
+def index_stale_sessions() -> dict:
+    """
+    Queue indexing for sessions whose transcripts have unindexed content.
+
+    A session needs (re)indexing when:
+    - it has never been indexed, or
+    - the transcript was modified after the last indexing run, or
+    - the last run happened while the transcript was still hot (its tail
+      segment was held back and no further writes will bump the mtime).
+    """
+    queued = 0
+    skipped = 0
+
+    with make_session() as db:
+        # Fetch only the columns the sweep needs instead of full ORM
+        # entities: the freshness check (file mtime vs indexed_at) can't
+        # move into SQL, so every candidate row still gets a per-file stat,
+        # but this keeps the hourly scan cheap as the session count grows.
+        rows = (
+            db.query(Session.id, Session.transcript_path, Session.indexed_at)
+            .filter(Session.transcript_path.isnot(None))
+            .all()
+        )
+
+        for session_id, transcript_path, indexed_at in rows:
+            if not transcript_path:
+                continue
+            transcript_file = settings.SESSIONS_STORAGE_DIR / transcript_path
+            if not transcript_file.exists():
+                skipped += 1
+                continue
+
+            mtime = datetime.fromtimestamp(
+                transcript_file.stat().st_mtime, tz=timezone.utc
+            )
+            tail_may_be_pending = indexed_at is not None and (
+                (indexed_at - mtime).total_seconds()
+                < settings.SESSION_INDEX_MIN_IDLE_SECONDS
+            )
+            needs_indexing = (
+                indexed_at is None or mtime > indexed_at or tail_may_be_pending
+            )
+            if not needs_indexing:
+                skipped += 1
+                continue
+
+            index_session.delay(str(session_id))  # type: ignore[attr-defined]
+            queued += 1
+
+    logger.info(f"Session indexing check: {queued} queued, {skipped} skipped")
+    return {"queued": queued, "skipped": skipped}

--- a/tests/memory/api/MCP/test_claude.py
+++ b/tests/memory/api/MCP/test_claude.py
@@ -1,12 +1,18 @@
 """Tests for MCP claude (cloud-claude session files) server."""
 # pyright: reportFunctionMemberAccess=false
 
+import json
+import uuid as uuid_lib
 from unittest.mock import AsyncMock, patch
 
 import pytest
 
 from memory.api.orchestrator_client import SessionInfo as OrchSessionInfo
+from memory.api.search.types import SearchResult
 from memory.api.transfer_tokens import verify_token
+from memory.common import settings as settings_module
+from memory.common.db.models import Session as CodingSession
+from memory.common.db.models import CodingProject, SessionSegment
 from tests.conftest import mcp_auth_context
 
 
@@ -372,14 +378,6 @@ async def test_session_push_url_rejects_traversal(
 
 
 # -- archived transcript search ----------------------------------------------
-
-import json
-import uuid as uuid_lib
-
-from memory.api.search.types import SearchResult
-from memory.common import settings as settings_module
-from memory.common.db.models import Session as CodingSession
-from memory.common.db.models import CodingProject, SessionSegment
 
 
 @pytest.fixture

--- a/tests/memory/api/MCP/test_claude.py
+++ b/tests/memory/api/MCP/test_claude.py
@@ -369,3 +369,273 @@ async def test_session_push_url_rejects_traversal(
             )
 
 
+
+
+# -- archived transcript search ----------------------------------------------
+
+import json
+import uuid as uuid_lib
+
+from memory.api.search.types import SearchResult
+from memory.common import settings as settings_module
+from memory.common.db.models import Session as CodingSession
+from memory.common.db.models import CodingProject, SessionSegment
+
+
+@pytest.fixture
+def sessions_dir(tmp_path):
+    sessions = tmp_path / "session_transcripts"
+    with patch.object(settings_module, "SESSIONS_STORAGE_DIR", sessions):
+        yield sessions
+
+
+def transcript_event(event_type: str, text: str, minute: int) -> dict:
+    return {
+        "uuid": str(uuid_lib.uuid4()),
+        "type": event_type,
+        "timestamp": f"2026-07-01T12:{minute:02d}:00Z",
+        "message": {"role": event_type, "content": text},
+    }
+
+
+def make_coding_session(db_session, user, sessions_dir, events=None, directory=None):
+    project = None
+    if directory:
+        project = CodingProject(user_id=user.id, directory=directory)
+        db_session.add(project)
+        db_session.flush()
+
+    session = CodingSession(
+        id=uuid_lib.uuid4(),
+        user_id=user.id,
+        coding_project_id=project and project.id,
+        transcript_path=f"{user.id}/{uuid_lib.uuid4()}.jsonl",
+        summary="worked on the thing",
+    )
+    db_session.add(session)
+    db_session.commit()
+
+    if events is not None:
+        file = sessions_dir / session.transcript_path
+        file.parent.mkdir(parents=True, exist_ok=True)
+        file.write_text("\n".join(json.dumps(e) for e in events) + "\n")
+
+    return session
+
+
+def make_segment(db_session, session, start=0, end=4, roles=("user", "assistant")):
+    segment = SessionSegment(
+        session_id=session.id,
+        start_index=start,
+        end_index=end,
+        roles=list(roles),
+        models=["claude-fable-5"],
+        content=f"User: segment content {start}",
+        sha256=uuid_lib.uuid4().bytes + uuid_lib.uuid4().bytes,
+        size=30,
+        creator_id=session.user_id,
+        project_id=None,
+        embed_status="STORED",
+    )
+    db_session.add(segment)
+    db_session.commit()
+    return segment
+
+
+@pytest.mark.asyncio
+async def test_session_fetch_owner_only(
+    db_session, admin_user, regular_user, user_session, sessions_dir
+):
+    from memory.api.MCP.servers.claude import session_fetch
+
+    other_session = make_coding_session(db_session, admin_user, sessions_dir, events=[])
+
+    with mcp_auth_context(user_session.id):
+        with pytest.raises(Exception, match="Session not found"):
+            await session_fetch.fn(session_id=str(other_session.id))
+
+
+@pytest.mark.asyncio
+async def test_session_fetch_pagination(
+    db_session, regular_user, user_session, sessions_dir
+):
+    from memory.api.MCP.servers.claude import session_fetch
+
+    events = [
+        transcript_event("user", f"question number {i}", minute=i) for i in range(6)
+    ]
+    session = make_coding_session(
+        db_session, regular_user, sessions_dir, events=events, directory="/code/memory"
+    )
+
+    with mcp_auth_context(user_session.id):
+        page1 = await session_fetch.fn(session_id=str(session.id), limit=4)
+
+    assert page1["project"] == "/code/memory"
+    assert page1["summary"] == "worked on the thing"
+    assert [m["index"] for m in page1["messages"]] == [0, 1, 2, 3]
+    assert page1["messages"][0]["role"] == "user"
+    assert page1["messages"][0]["text"] == "question number 0"
+    assert page1["next_index"] == 4
+
+    with mcp_auth_context(user_session.id):
+        page2 = await session_fetch.fn(
+            session_id=str(session.id), start_index=page1["next_index"], limit=4
+        )
+
+    assert [m["index"] for m in page2["messages"]] == [4, 5]
+    assert page2["next_index"] is None
+
+
+@pytest.mark.asyncio
+async def test_session_fetch_around_time(
+    db_session, regular_user, user_session, sessions_dir
+):
+    from memory.api.MCP.servers.claude import session_fetch
+
+    events = [
+        transcript_event("user", f"message at minute {i}", minute=i) for i in range(10)
+    ]
+    session = make_coding_session(db_session, regular_user, sessions_dir, events=events)
+
+    with mcp_auth_context(user_session.id):
+        result = await session_fetch.fn(
+            session_id=str(session.id),
+            around_time="2026-07-01T12:05:00Z",
+            limit=4,
+        )
+
+    indices = [m["index"] for m in result["messages"]]
+    assert len(indices) == 4
+    assert 5 in indices  # pivot message included
+    assert indices == sorted(indices)
+    assert indices[0] < 5  # window includes context before the pivot
+
+
+@pytest.mark.asyncio
+async def test_session_fetch_no_transcript(
+    db_session, regular_user, user_session, sessions_dir
+):
+    from memory.api.MCP.servers.claude import session_fetch
+
+    session = make_coding_session(db_session, regular_user, sessions_dir)
+
+    with mcp_auth_context(user_session.id):
+        result = await session_fetch.fn(session_id=str(session.id))
+
+    assert result["messages"] == []
+    assert result["next_index"] is None
+
+
+def test_owned_segment_ids_scopes_to_owner(
+    db_session, admin_user, regular_user, sessions_dir
+):
+    from memory.api.MCP.servers.claude import owned_segment_ids
+
+    mine = make_coding_session(
+        db_session, regular_user, sessions_dir, directory="/code/memory"
+    )
+    theirs = make_coding_session(
+        db_session, admin_user, sessions_dir, directory="/code/memory"
+    )
+    my_segment = make_segment(db_session, mine)
+    make_segment(db_session, theirs)
+
+    assert owned_segment_ids(regular_user.id) == [my_segment.id]
+
+
+def test_owned_segment_ids_filters(db_session, regular_user, sessions_dir):
+    from memory.api.MCP.servers.claude import owned_segment_ids
+
+    memory_session = make_coding_session(
+        db_session, regular_user, sessions_dir, directory="/code/memory"
+    )
+    other_session = make_coding_session(
+        db_session, regular_user, sessions_dir, directory="/code/other"
+    )
+    memory_segment = make_segment(db_session, memory_session)
+    user_only_segment = make_segment(
+        db_session, other_session, start=10, end=12, roles=("user",)
+    )
+
+    assert owned_segment_ids(regular_user.id, project="memory") == [memory_segment.id]
+    assert owned_segment_ids(regular_user.id, role="assistant") == [memory_segment.id]
+    assert sorted(owned_segment_ids(regular_user.id, role="user")) == sorted(
+        [memory_segment.id, user_only_segment.id]
+    )
+
+
+@pytest.mark.asyncio
+async def test_session_search_no_sessions_skips_search(
+    db_session, regular_user, user_session, sessions_dir
+):
+    from memory.api.MCP.servers import claude
+
+    with patch.object(claude, "search_base", new=AsyncMock()) as mock_search:
+        with mcp_auth_context(user_session.id):
+            result = await claude.session_search.fn(query="anything")
+
+    assert result == []
+    mock_search.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_session_search_formats_hits(
+    db_session, regular_user, user_session, sessions_dir
+):
+    from memory.api.MCP.servers import claude
+
+    session = make_coding_session(
+        db_session, regular_user, sessions_dir, directory="/code/memory"
+    )
+    segment = make_segment(db_session, session)
+
+    fake_result = SearchResult(
+        id=segment.id,
+        chunks=["User: how do I fuse RRF scores?"],
+        metadata=dict(segment.as_payload()),
+        search_score=0.87,
+    )
+
+    with patch.object(
+        claude, "search_base", new=AsyncMock(return_value=[fake_result])
+    ) as mock_search:
+        with mcp_auth_context(user_session.id):
+            hits = await claude.session_search.fn(query="rrf fusion")
+
+    mock_search.assert_called_once()
+    _, kwargs = mock_search.call_args
+    assert kwargs["modalities"] == {"session"}
+    assert kwargs["filters"]["source_ids"] == [segment.id]
+
+    assert len(hits) == 1
+    hit = hits[0]
+    assert hit["session_id"] == str(session.id)
+    assert hit["project"] == "/code/memory"
+    assert hit["session_summary"] == "worked on the thing"
+    assert hit["start_index"] == 0
+    assert hit["end_index"] == 4
+    assert hit["roles"] == ["user", "assistant"]
+    assert hit["models"] == ["claude-fable-5"]
+    assert hit["score"] == 0.87
+    assert "RRF" in hit["snippet"]
+
+
+@pytest.mark.asyncio
+async def test_generic_tools_never_expose_session_segments(
+    db_session, admin_user, admin_session, sessions_dir
+):
+    """Even superadmins must not reach session segments via list/count/fetch."""
+    from memory.api.MCP.servers.core import count_items, fetch, list_items
+
+    session = make_coding_session(db_session, admin_user, sessions_dir)
+    segment = make_segment(db_session, session)
+
+    with mcp_auth_context(admin_session.id):
+        listed = await list_items.fn(modalities={"session"})
+        counted = await count_items.fn(modalities={"session"})
+        fetched = await fetch.fn(ids=[segment.id])
+
+    assert listed["items"] == []
+    assert counted["total"] == 0
+    assert fetched == []

--- a/tests/memory/api/MCP/test_meta.py
+++ b/tests/memory/api/MCP/test_meta.py
@@ -1895,3 +1895,24 @@ async def test_unwatch_market_success(mock_scope):
     assert result["market_id"] == "m1"
     mock_db_session.delete.assert_called_once_with(mock_watched)
     mock_db_session.commit.assert_called_once()
+
+
+@pytest.mark.asyncio
+@patch("memory.api.MCP.servers.meta.get_schema")
+@patch("memory.api.MCP.servers.meta.qdrant")
+async def test_get_metadata_schemas_excludes_session_collections(
+    mock_qdrant, mock_get_schema
+):
+    """Session transcript collections are owner-only and never advertised."""
+    mock_client = MagicMock()
+    mock_qdrant.get_qdrant_client.return_value = mock_client
+    mock_qdrant.get_collection_sizes.return_value = {
+        "mail": 75,
+        "session": 1234,
+    }
+    mock_get_schema.return_value = {}
+
+    result = await get_metadata_schemas.fn()
+
+    assert "session" not in result
+    assert "mail" in result

--- a/tests/memory/parsers/test_claude_sessions.py
+++ b/tests/memory/parsers/test_claude_sessions.py
@@ -1,0 +1,198 @@
+import json
+
+import pytest
+
+from memory.parsers.claude_sessions import (
+    MAX_MESSAGE_CHARS,
+    build_segments,
+    extract_text_blocks,
+    iter_transcript_messages,
+    parse_event,
+)
+
+
+def make_event(
+    event_type: str = "user",
+    content: str | list | None = "hello there, this is a message",
+    timestamp: str = "2026-07-01T12:00:00Z",
+    is_meta: bool = False,
+    model: str | None = None,
+) -> dict:
+    message: dict = {"role": event_type, "content": content}
+    if model:
+        message["model"] = model
+    return {
+        "uuid": "some-uuid",
+        "type": event_type,
+        "timestamp": timestamp,
+        "message": message,
+        "is_meta": is_meta,
+    }
+
+
+@pytest.mark.parametrize(
+    "content, expected",
+    [
+        ("plain string", "plain string"),
+        ("  padded  ", "padded"),
+        ([{"type": "text", "text": "block text"}], "block text"),
+        (
+            [
+                {"type": "text", "text": "first"},
+                {"type": "tool_use", "name": "Bash", "input": {"command": "ls"}},
+                {"type": "text", "text": "second"},
+            ],
+            "first\nsecond",
+        ),
+        ([{"type": "tool_result", "content": "output"}], ""),
+        ([{"type": "thinking", "thinking": "hmm"}], ""),
+        ({"weird": "shape"}, ""),
+        (None, ""),
+        ([], ""),
+    ],
+)
+def test_extract_text_blocks(content, expected):
+    assert extract_text_blocks(content) == expected
+
+
+def test_parse_event_user_message():
+    message = parse_event(3, make_event("user", "what does this code do?"))
+    assert message is not None
+    assert message.index == 3
+    assert message.role == "user"
+    assert message.text == "what does this code do?"
+    assert message.timestamp is not None
+    assert message.timestamp.isoformat() == "2026-07-01T12:00:00+00:00"
+    assert message.model is None
+
+
+def test_parse_event_assistant_records_model():
+    message = parse_event(
+        0, make_event("assistant", "the code does X", model="claude-fable-5")
+    )
+    assert message is not None
+    assert message.model == "claude-fable-5"
+
+
+@pytest.mark.parametrize(
+    "event",
+    [
+        make_event("user", "hi", is_meta=True),
+        make_event("system", "system prompt"),
+        make_event("user", [{"type": "tool_result", "content": "stdout"}]),
+        make_event("user", ""),
+        {"type": "user"},  # no message at all
+    ],
+)
+def test_parse_event_skips_non_conversation(event):
+    assert parse_event(0, event) is None
+
+
+def test_parse_event_truncates_long_messages():
+    message = parse_event(0, make_event("user", "x" * (MAX_MESSAGE_CHARS + 100)))
+    assert message is not None
+    assert len(message.text) < MAX_MESSAGE_CHARS + 50
+    assert message.text.endswith("[... truncated]")
+
+
+def write_transcript(path, events):
+    path.write_text("\n".join(json.dumps(e) for e in events) + "\n")
+
+
+def test_iter_transcript_messages_indices_and_filtering(tmp_path):
+    file = tmp_path / "transcript.jsonl"
+    events = [
+        make_event("user", "first question"),  # 0
+        make_event("assistant", "tool call incoming"),  # 1
+        make_event("user", [{"type": "tool_result", "content": "out"}]),  # 2
+        make_event("assistant", "the answer"),  # 3
+    ]
+    write_transcript(file, events)
+
+    messages = list(iter_transcript_messages(file))
+    assert [(m.index, m.role) for m in messages] == [
+        (0, "user"),
+        (1, "assistant"),
+        (3, "assistant"),
+    ]
+
+
+def test_iter_transcript_messages_start_index(tmp_path):
+    file = tmp_path / "transcript.jsonl"
+    write_transcript(
+        file, [make_event("user", f"message number {i}") for i in range(5)]
+    )
+
+    messages = list(iter_transcript_messages(file, start_index=3))
+    assert [m.index for m in messages] == [3, 4]
+
+
+def test_iter_transcript_messages_malformed_lines_keep_indices(tmp_path):
+    file = tmp_path / "transcript.jsonl"
+    lines = [
+        json.dumps(make_event("user", "first")),
+        "{not json",
+        "",
+        json.dumps(make_event("user", "second")),
+    ]
+    file.write_text("\n".join(lines) + "\n")
+
+    messages = list(iter_transcript_messages(file))
+    assert [m.index for m in messages] == [0, 3]
+
+
+def test_build_segments_respects_token_budget():
+    events = [make_event("user", f"message {i}: " + "word " * 40) for i in range(6)]
+    messages = [m for i, e in enumerate(events) if (m := parse_event(i, e))]
+
+    segments = build_segments(messages, max_tokens=100)
+
+    assert len(segments) > 1
+    # Every message lands in exactly one segment, in order
+    all_indices = [m.index for s in segments for m in s.messages]
+    assert all_indices == list(range(6))
+    # Segments carry inclusive line ranges
+    assert segments[0].start_index == 0
+    assert segments[-1].end_index == 5
+
+
+def test_build_segments_metadata():
+    messages = [
+        parse_event(0, make_event("user", "question about the parser")),
+        parse_event(
+            2, make_event("assistant", "answer about the parser", model="claude-fable-5")
+        ),
+    ]
+    segments = build_segments([m for m in messages if m], max_tokens=1000)
+
+    assert len(segments) == 1
+    segment = segments[0]
+    assert segment.start_index == 0
+    assert segment.end_index == 2
+    assert segment.roles == ["assistant", "user"]
+    assert segment.models == ["claude-fable-5"]
+    assert "User: question about the parser" in segment.text
+    assert "Assistant: answer about the parser" in segment.text
+    assert segment.start_time is not None
+    assert segment.end_time is not None
+
+
+def test_build_segments_deterministic():
+    events = [make_event("user", f"message {i}: " + "word " * 30) for i in range(8)]
+
+    def run():
+        messages = [m for i, e in enumerate(events) if (m := parse_event(i, e))]
+        return [(s.start_index, s.end_index, s.text) for s in build_segments(messages, max_tokens=120)]
+
+    assert run() == run()
+
+
+def test_build_segments_oversized_message_gets_own_segment():
+    messages = [
+        parse_event(0, make_event("user", "short lead-in")),
+        parse_event(1, make_event("assistant", "word " * 500)),
+        parse_event(2, make_event("user", "short follow-up")),
+    ]
+    segments = build_segments([m for m in messages if m], max_tokens=100)
+
+    assert [len(s.messages) for s in segments] == [1, 1, 1]

--- a/tests/memory/workers/tasks/test_sessions_tasks.py
+++ b/tests/memory/workers/tasks/test_sessions_tasks.py
@@ -1,0 +1,292 @@
+"""Tests for session transcript search indexing (index_session & friends)."""
+
+import json
+import os
+import time
+import uuid
+from datetime import datetime, timezone
+from unittest.mock import patch
+
+import pytest
+
+from memory.common import settings
+from memory.common.db.models import Chunk, Session, SessionSegment, SourceItem
+from memory.workers.tasks import sessions as sessions_tasks
+from memory.workers.tasks.maintenance import cleanup_old_claude_sessions
+
+
+def make_event(event_type: str, text: str, timestamp: str) -> dict:
+    return {
+        "uuid": str(uuid.uuid4()),
+        "type": event_type,
+        "timestamp": timestamp,
+        "message": {"role": event_type, "content": text},
+    }
+
+
+def make_events(count: int, words_per_message: int = 60) -> list[dict]:
+    return [
+        make_event(
+            "user" if i % 2 == 0 else "assistant",
+            f"message {i}: " + "word " * words_per_message,
+            f"2026-07-01T12:{i:02d}:00Z",
+        )
+        for i in range(count)
+    ]
+
+
+def write_transcript(path, events, age_seconds: int = 7200):
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text("\n".join(json.dumps(e) for e in events) + "\n")
+    mtime = time.time() - age_seconds
+    os.utime(path, (mtime, mtime))
+
+
+def make_chunk(item: SourceItem) -> Chunk:
+    return Chunk(
+        id=str(uuid.uuid4()),
+        source=item,
+        content=item.content,
+        embedding_model="test-model",
+        vector=[0.1] * 1024,
+        item_metadata={},
+        collection_name="session",
+    )
+
+
+@pytest.fixture
+def sessions_dir(tmp_path):
+    with patch.object(settings, "SESSIONS_STORAGE_DIR", tmp_path / "sessions"):
+        yield tmp_path / "sessions"
+
+
+@pytest.fixture
+def indexing_env(db_session, sessions_dir):
+    """Route the task's DB access to the test session and stub out embedding."""
+
+    def fake_session():
+        class Ctx:
+            def __enter__(self):
+                return db_session
+
+            def __exit__(self, *args):
+                pass
+
+        return Ctx()
+
+    with (
+        patch("memory.workers.tasks.sessions.make_session", fake_session),
+        patch(
+            "memory.common.embedding.embed_source_item",
+            side_effect=lambda item: [make_chunk(item)],
+        ),
+        patch("memory.common.content_processing.push_chunks_to_qdrant"),
+    ):
+        yield db_session
+
+
+@pytest.fixture
+def coding_session(indexing_env, regular_user, sessions_dir):
+    session = Session(
+        id=uuid.uuid4(),
+        user_id=regular_user.id,
+        transcript_path="1/test-session.jsonl",
+    )
+    indexing_env.add(session)
+    indexing_env.commit()
+    return session
+
+
+def test_index_session_creates_segments(indexing_env, coding_session, sessions_dir):
+    write_transcript(
+        sessions_dir / coding_session.transcript_path, make_events(12)
+    )
+
+    result = sessions_tasks.index_session(str(coding_session.id))
+
+    assert result["status"] == "success"
+    assert result["created"] > 0
+    assert result["duplicates"] == 0
+
+    segments = indexing_env.query(SessionSegment).all()
+    assert len(segments) == result["created"]
+    for segment in segments:
+        assert segment.session_id == coding_session.id
+        assert segment.creator_id == coding_session.user_id
+        assert segment.project_id is None
+        assert segment.project_id_inherited is False
+        assert segment.modality == "session"
+        assert segment.embed_status == "STORED"
+        assert "message" in segment.content
+        assert segment.roles == ["assistant", "user"]
+
+    # Watermark advanced past the last message of the last segment
+    assert coding_session.indexed_up_to == 12
+    assert coding_session.indexed_at is not None
+
+
+def test_index_session_is_idempotent(indexing_env, coding_session, sessions_dir):
+    write_transcript(sessions_dir / coding_session.transcript_path, make_events(12))
+
+    first = sessions_tasks.index_session(str(coding_session.id))
+
+    # Reset the watermark to simulate a re-run over the same content
+    coding_session.indexed_up_to = 0
+    indexing_env.commit()
+
+    second = sessions_tasks.index_session(str(coding_session.id))
+
+    assert second["created"] == 0
+    assert second["duplicates"] == first["created"]
+    assert indexing_env.query(SessionSegment).count() == first["created"]
+
+
+def test_index_session_holds_back_hot_tail(indexing_env, coding_session, sessions_dir):
+    # Recently-modified transcript: the trailing partial segment must wait
+    write_transcript(
+        sessions_dir / coding_session.transcript_path,
+        make_events(2, words_per_message=5),
+        age_seconds=0,
+    )
+
+    result = sessions_tasks.index_session(str(coding_session.id))
+
+    assert result["created"] == 0
+    assert coding_session.indexed_up_to == 0
+
+
+def test_index_session_incremental(indexing_env, coding_session, sessions_dir):
+    transcript = sessions_dir / coding_session.transcript_path
+    events = make_events(12)
+    write_transcript(transcript, events)
+
+    first = sessions_tasks.index_session(str(coding_session.id))
+
+    write_transcript(transcript, events + make_events(24)[12:])
+    second = sessions_tasks.index_session(str(coding_session.id))
+
+    assert second["created"] > 0
+    assert second["duplicates"] == 0
+    assert (
+        indexing_env.query(SessionSegment).count()
+        == first["created"] + second["created"]
+    )
+    assert coding_session.indexed_up_to == 24
+
+
+def test_index_session_missing_transcript(indexing_env, coding_session):
+    result = sessions_tasks.index_session(str(coding_session.id))
+    assert result["status"] == "skipped"
+
+
+def test_index_session_invalid_uuid(indexing_env):
+    result = sessions_tasks.index_session("not-a-uuid")
+    assert result["status"] == "error"
+
+
+def test_index_stale_sessions_queues_only_stale(
+    indexing_env, regular_user, sessions_dir
+):
+    stale = Session(
+        id=uuid.uuid4(), user_id=regular_user.id, transcript_path="1/stale.jsonl"
+    )
+    fresh = Session(
+        id=uuid.uuid4(),
+        user_id=regular_user.id,
+        transcript_path="1/fresh.jsonl",
+        indexed_at=datetime.now(timezone.utc),
+    )
+    indexing_env.add_all([stale, fresh])
+    indexing_env.commit()
+
+    write_transcript(sessions_dir / "1/stale.jsonl", make_events(2))
+    write_transcript(sessions_dir / "1/fresh.jsonl", make_events(2))
+
+    with patch.object(sessions_tasks.index_session, "delay") as mock_delay:
+        result = sessions_tasks.index_stale_sessions()
+
+    assert result["queued"] == 1
+    mock_delay.assert_called_once_with(str(stale.id))
+
+
+def test_index_stale_sessions_requeues_pending_tail(
+    indexing_env, regular_user, sessions_dir
+):
+    # Indexed while the transcript was still hot: the tail is pending even
+    # though the file hasn't changed since.
+    session = Session(
+        id=uuid.uuid4(),
+        user_id=regular_user.id,
+        transcript_path="1/hot.jsonl",
+        indexed_at=datetime.now(timezone.utc),
+    )
+    indexing_env.add(session)
+    indexing_env.commit()
+    write_transcript(sessions_dir / "1/hot.jsonl", make_events(2), age_seconds=60)
+
+    with patch.object(sessions_tasks.index_session, "delay") as mock_delay:
+        result = sessions_tasks.index_stale_sessions()
+
+    assert result["queued"] == 1
+    mock_delay.assert_called_once_with(str(session.id))
+
+
+def test_cleanup_old_sessions_removes_segments(
+    indexing_env, coding_session, sessions_dir
+):
+    write_transcript(sessions_dir / coding_session.transcript_path, make_events(12))
+    sessions_tasks.index_session(str(coding_session.id))
+    assert indexing_env.query(SessionSegment).count() > 0
+
+    with patch("memory.workers.tasks.maintenance.make_session", lambda: _ctx(indexing_env)):
+        cleanup_old_claude_sessions(max_age_days=0)
+
+    assert indexing_env.query(SessionSegment).count() == 0
+    assert indexing_env.query(SourceItem).count() == 0
+    assert indexing_env.query(Session).count() == 0
+
+
+class _ctx:
+    def __init__(self, session):
+        self.session = session
+
+    def __enter__(self):
+        return self.session
+
+    def __exit__(self, *args):
+        pass
+
+
+def test_index_session_halts_watermark_on_embedding_failure(
+    indexing_env, coding_session, sessions_dir
+):
+    write_transcript(sessions_dir / coding_session.transcript_path, make_events(12))
+
+    calls = {"count": 0}
+
+    def flaky_embed(item):
+        calls["count"] += 1
+        if calls["count"] >= 2:
+            raise IOError("voyage is down")
+        return [make_chunk(item)]
+
+    with patch("memory.common.embedding.embed_source_item", side_effect=flaky_embed):
+        result = sessions_tasks.index_session(str(coding_session.id))
+
+    assert result["status"] == "partial"
+    assert result["created"] == 1
+    # The failed row was dropped and the watermark halted before it,
+    # so the slice stays retryable; indexed_at stays unset so the
+    # stale-session sweep requeues this session.
+    segments = indexing_env.query(SessionSegment).all()
+    assert len(segments) == 1
+    assert coding_session.indexed_up_to == segments[0].end_index + 1
+    assert coding_session.indexed_at is None
+
+    # Once embedding recovers, the remaining slice is indexed.
+    recovery = sessions_tasks.index_session(str(coding_session.id))
+
+    assert recovery["status"] == "success"
+    assert recovery["created"] >= 1
+    assert coding_session.indexed_up_to == 12
+    assert coding_session.indexed_at is not None


### PR DESCRIPTION
Closes #100.

Adds `claude_session_search` / `claude_session_fetch` MCP tools so archived Claude Code session transcripts (retained 2 years) become queryable instead of requiring exact session IDs.

## What's here

- **`SessionSegment` SourceItem subtype** — embedding-sized runs of conversational messages (tool traffic stripped) riding the standard hybrid pipeline (Qdrant + BM25 + RRF) in a new `session` collection, with transcript line indices pointing back into the JSONL for context windows.
- **Indexer** — hourly `index_stale_sessions` sweep + per-session `index_session` task with an `indexed_up_to` watermark. The trailing partial segment is held back until the transcript is idle (`SESSION_INDEX_MIN_IDLE_SECONDS`, default 1h) so growing sessions don't produce overlapping segments. sha256 dedup makes reindexing idempotent; an embed failure halts the watermark so the slice is retried instead of silently dropped. Existing sessions backfill automatically on first sweep.
- **Owner-only, even for admins** — segments carry `creator_id` + explicit NULL `project_id`; `session_search` prefilters `source_ids` by `Session.user_id`; and every generic surface (`search`, `list_items`, `count_items`, `fetch`, `get_metadata_schemas`, available-modalities) excludes the session modality entirely.
- **Retention** — `cleanup_old_claude_sessions` now deletes segment `source_item` parent rows (Qdrant points are GC'd by the existing clean-all-collections sweep).
- **Acceptance criterion from the issue**: "when did we discuss X?" resolves in two tool calls — `claude_session_search(query)` → `claude_session_fetch(session_id, start_index)`.

## Review

3 rounds of differ-review (all comments resolved): round 1 fixed LIKE-wildcard escaping, lean SearchConfig (no HyDE/query-analysis LLM calls), and a cheaper hourly sweep; round 2 verified fixes, no new findings; round 3 fixed the embed-failure watermark gap, the `get_metadata_schemas` session leak, and a negative-limit edge. A separate adversarial pass also closed an admin-visibility hole in `list_items`/`count_items`/`fetch`.

Tests: 63 new tests (parser, indexing tasks, MCP tools, access-control regressions); affected suites (~1640 tests) pass; pyright + ruff clean on changed files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012YX6tYnmz3K8LZg6MXfHCv