### PR TITLE
fix(slack): robust workspace setup (resumable wizard, user-token OAuth, scope parsing)

### DIFF
--- a/README.md
+++ b/README.md
@@ -188,6 +188,26 @@ python tools/discord_setup.py generate-invite --bot-token <your bot token>
 
 That returns an invite URL for adding the bot to your server.
 
+### Slack integration
+
+Set up through the web UI: Sources -> Slack -> Connect Workspace. Slack must reach this instance over public HTTPS for the OAuth callback and the events webhook, so `SERVER_URL` must be a public URL. For a local instance, expose it with a tunnel (e.g. Cloudflare Tunnel) and set `SERVER_URL` to the tunnel hostname.
+
+The app authenticates as a Slack **user**, not a bot. It reads only channels and DMs that user is in, and stores per-user credentials. Do not add bot scopes: requesting bot `scope` fails the install with "doesn't have a bot user to install".
+
+Steps:
+
+1. Create an app at [api.slack.com/apps](https://api.slack.com/apps) (From scratch). Note the Client ID, Client Secret, and Signing Secret from Basic Information.
+2. In the wizard, enter the Client ID, then the Client Secret. The wizard shows the exact redirect URL and events Request URL to paste into Slack.
+3. Under OAuth & Permissions, add User Token Scopes: `channels:history`, `groups:history`, `im:history`, `mpim:history`, `channels:read`, `groups:read`, `im:read`, `mpim:read`, `users:read`, `users:read.email`, `team:read`, `reactions:read`, `files:read`. The wizard requests exactly this set.
+4. Authorize the workspace.
+5. Paste the Signing Secret into the wizard.
+6. Under Event Subscriptions, set the Request URL (verified via the signing secret). Then under "Subscribe to events on behalf of users" add `message.channels`, `message.groups`, `message.im`, `message.mpim`. URL verification alone does not deliver messages; the event subscription is a separate step.
+7. Post the wizard's test token in any channel or DM you are in. Receiving that message event flips the app to `live`.
+
+Syncing runs only when `setup_state` is `live` or `degraded` and message collection is enabled. Enable collection per workspace; channels inherit the workspace setting unless overridden per channel. A large workspace backfills slowly because Slack rate-limits history reads. Ingested messages are searchable under the `message` modality.
+
+Setup state is held in the API process memory during the wizard (`_wizard_nonces`, `_test_message_tokens`), so restarting the API mid-setup drops the current nonce and test token; re-issue them from the wizard if that happens.
+
 ### Manually triggering Celery tasks
 
 ```bash

--- a/frontend/src/components/sources/panels/SlackAppWizard.test.tsx
+++ b/frontend/src/components/sources/panels/SlackAppWizard.test.tsx
@@ -158,6 +158,12 @@ describe('SlackAppWizard - oauth redirect', () => {
     expect(url).toContain('https://slack.com/oauth/v2/authorize?')
     expect(url).toContain('client_id=cid-123')
     expect(url).toContain('state=signed-state')
+    // User-token-only install: scopes ride on user_scope, and there must be NO
+    // bot `scope` param — requesting it makes Slack demand a bot user the app
+    // never uses and fails the install with "doesn't have a bot user".
+    const params = new URLSearchParams(url.split('?')[1])
+    expect(params.get('user_scope')).toContain('channels:history')
+    expect(params.has('scope')).toBe(false)
     openSpy.mockRestore()
   })
 })

--- a/frontend/src/components/sources/panels/SlackAppWizard.tsx
+++ b/frontend/src/components/sources/panels/SlackAppWizard.tsx
@@ -36,12 +36,27 @@ const SETUP_STATE_TO_STEP: Record<string, Step> = {
   degraded: 'done',
 }
 
+// Resume an existing app at the first UNFINISHED step. Keying off setup_state
+// alone is wrong for a reopened `draft` app: the client secret may already be
+// set and OAuth already completed (e.g. reopened via "Finish setup"), so
+// restarting at client-secret re-triggers a redundant OAuth and loops the user.
+// The per-secret / auth flags say what's actually left to do.
+const resumeStep = (app: SlackAppResponse): Step => {
+  if (app.setup_state === 'live' || app.setup_state === 'degraded') return 'done'
+  if (app.setup_state === 'signing_verified') return 'test-message'
+  if (!app.client_secret_configured) return 'client-secret'
+  if (!app.is_authorized) return 'oauth'
+  if (!app.signing_secret_configured) return 'signing-secret'
+  return 'events-url'
+}
+
 const POLL_INTERVAL_MS = 3000
 
-// OAuth scopes requested for both bot and user tokens. Read-only across
-// the workspace surface (channels/groups/im/mpim history + read), users +
-// emails for mention resolution, reactions/files for the existing message
-// processing pipeline. Keep aligned with the backend's expectations.
+// User token scopes requested during OAuth (sent as `user_scope`; the app
+// authenticates as the user, not a bot). Read-only by design: the integration
+// ingests Slack content and never posts. Covers channel/group/im/mpim history +
+// read, users/emails for mention resolution, and reactions/files for the
+// message pipeline. Keep aligned with the README Slack section.
 const SLACK_OAUTH_SCOPES = [
   'channels:history',
   'groups:history',
@@ -79,7 +94,7 @@ export const SlackAppWizard = ({
   const [app, setApp] = useState<SlackAppResponse | null>(initialApp)
   const [step, setStep] = useState<Step>(() => {
     if (!initialApp) return 'register'
-    return SETUP_STATE_TO_STEP[initialApp.setup_state] ?? 'client-secret'
+    return resumeStep(initialApp)
   })
   const [error, setError] = useState<string | null>(null)
   const [busy, setBusy] = useState(false)
@@ -155,6 +170,24 @@ export const SlackAppWizard = ({
     return () => channel.close()
   }, [app, step, wizard, authUser])
 
+  // The wizard nonce (callback + events URLs) is normally issued in the
+  // client-secret step. When resuming an app past that point (via resumeStep),
+  // fetch it so the oauth/signing-secret/events-url steps aren't left blank.
+  useEffect(() => {
+    if (!app || nonceData) return
+    if (step !== 'oauth' && step !== 'signing-secret' && step !== 'events-url') return
+    let cancelled = false
+    wizard
+      .issueWizardNonce(app.id)
+      .then(n => {
+        if (!cancelled) setNonceData(n)
+      })
+      .catch(e => console.warn('Wizard nonce fetch failed:', e))
+    return () => {
+      cancelled = true
+    }
+  }, [app, step, nonceData, wizard])
+
   const handleError = (e: unknown) => setError((e as Error).message)
   const clearError = () => setError(null)
 
@@ -213,7 +246,10 @@ export const SlackAppWizard = ({
       const state = await wizard.issueOAuthState(app.id)
       const params = new URLSearchParams({
         client_id: app.client_id,
-        scope: SLACK_OAUTH_SCOPES,
+        // User-token-only install: the backend stores and uses only the
+        // authed_user token (see slack.py oauth exchange + SlackUserCredentials);
+        // requesting bot `scope` would force a bot user the app never uses and
+        // breaks install with "no bot user to install".
         user_scope: SLACK_OAUTH_SCOPES,
         redirect_uri: callbackUrl,
         state,

--- a/frontend/src/components/sources/panels/SlackPanel.test.tsx
+++ b/frontend/src/components/sources/panels/SlackPanel.test.tsx
@@ -8,6 +8,7 @@ const triggerSync = vi.fn()
 const listChannels = vi.fn()
 const updateChannel = vi.fn()
 const listProjects = vi.fn()
+const listApps = vi.fn()
 
 vi.mock('@/hooks/useSlack', () => ({
   useSlack: () => ({
@@ -22,6 +23,12 @@ vi.mock('@/hooks/useSlack', () => ({
 
 vi.mock('@/hooks/useProjects', () => ({
   useProjects: () => ({ listProjects }),
+}))
+
+// The panel loads apps (for the "Finish setup" resume banner) alongside
+// workspaces; stub it so the real useAuth().apiCall isn't hit.
+vi.mock('@/hooks/useSlackWizard', () => ({
+  useSlackWizard: () => ({ listApps }),
 }))
 
 vi.mock('../Sources', () => ({
@@ -73,6 +80,7 @@ const channel = (over: Record<string, unknown> = {}) => ({
 beforeEach(() => {
   vi.clearAllMocks()
   listWorkspaces.mockResolvedValue([])
+  listApps.mockResolvedValue([])
   listProjects.mockResolvedValue([{ id: 9, title: 'Proj', repo_path: 'o/r' }])
   listChannels.mockResolvedValue([channel()])
   updateWorkspace.mockResolvedValue(workspace())

--- a/frontend/src/components/sources/panels/SlackPanel.tsx
+++ b/frontend/src/components/sources/panels/SlackPanel.tsx
@@ -1,5 +1,6 @@
 import { useState, useEffect, useCallback } from 'react'
 import { useSlack, SlackWorkspace, SlackChannel, SlackChannelUpdate, SlackWorkspaceUpdate } from '@/hooks/useSlack'
+import { useSlackWizard, SlackAppResponse } from '@/hooks/useSlackWizard'
 import { useProjects, Project } from '@/hooks/useProjects'
 import {
   EmptyState,
@@ -24,6 +25,7 @@ export const SlackPanel = () => {
     updateChannel,
   } = useSlack()
   const { listProjects } = useProjects()
+  const { listApps } = useSlackWizard()
 
   const [workspaces, setWorkspaces] = useState<SlackWorkspace[]>([])
   const [channelsByWorkspace, setChannelsByWorkspace] = useState<Record<string, SlackChannel[]>>({})
@@ -33,23 +35,32 @@ export const SlackPanel = () => {
   const [error, setError] = useState<string | null>(null)
   const [disconnecting, setDisconnecting] = useState<SlackWorkspace | null>(null)
   const [wizardOpen, setWizardOpen] = useState(false)
+  // Apps that haven't finished the setup wizard (still draft/signing_verified).
+  // The panel otherwise only lists connected workspaces, which strands a
+  // half-configured app with no way back into the wizard to reach 'live'.
+  const [unfinishedApps, setUnfinishedApps] = useState<SlackAppResponse[]>([])
+  const [wizardInitialApp, setWizardInitialApp] = useState<SlackAppResponse | null>(null)
 
   const loadData = useCallback(async () => {
     setLoading(true)
     setError(null)
     try {
-      const [workspacesData, projectsData] = await Promise.all([
+      const [workspacesData, projectsData, appsData] = await Promise.all([
         listWorkspaces(userId),
-        listProjects()
+        listProjects(),
+        listApps(),
       ])
       setWorkspaces(workspacesData)
       setProjects(projectsData)
+      setUnfinishedApps(
+        appsData.filter(a => a.setup_state !== 'live' && a.setup_state !== 'degraded')
+      )
     } catch (e) {
       setError(e instanceof Error ? e.message : 'Failed to load workspaces')
     } finally {
       setLoading(false)
     }
-  }, [listWorkspaces, listProjects, userId])
+  }, [listWorkspaces, listProjects, listApps, userId])
 
   useEffect(() => {
     loadData()
@@ -83,11 +94,20 @@ export const SlackPanel = () => {
   const handleConnect = () => {
     // Per-app wizard flow: register a SlackApp first, then OAuth into it.
     // No env-var single-app `/slack/authorize` endpoint anymore.
+    setWizardInitialApp(null)
+    setWizardOpen(true)
+  }
+
+  const handleResumeSetup = (appToResume: SlackAppResponse) => {
+    // Reopen the wizard on an existing, half-configured app so the remaining
+    // steps (signing-secret, events-url, test-message) can flip it to 'live'.
+    setWizardInitialApp(appToResume)
     setWizardOpen(true)
   }
 
   const handleWizardComplete = () => {
     setWizardOpen(false)
+    setWizardInitialApp(null)
     loadData()
   }
 
@@ -152,10 +172,33 @@ export const SlackPanel = () => {
         </button>
       </div>
 
+      {unfinishedApps.length > 0 && !wizardOpen && (
+        <div className={styles.sourceList}>
+          {unfinishedApps.map(app => (
+            <div
+              key={app.id}
+              className="flex items-center justify-between gap-3 rounded border border-yellow-300 bg-yellow-50 p-3 text-sm text-yellow-900"
+            >
+              <span>
+                Slack app "{app.name}" setup is incomplete ({app.setup_state}) — finish
+                it to enable automatic sync and real-time updates.
+              </span>
+              <button className={styles.btnAdd} onClick={() => handleResumeSetup(app)}>
+                Finish setup
+              </button>
+            </div>
+          ))}
+        </div>
+      )}
+
       {wizardOpen && (
         <SlackAppWizard
+          initialApp={wizardInitialApp}
           onComplete={handleWizardComplete}
-          onCancel={() => setWizardOpen(false)}
+          onCancel={() => {
+            setWizardOpen(false)
+            setWizardInitialApp(null)
+          }}
         />
       )}
 

--- a/src/memory/api/slack.py
+++ b/src/memory/api/slack.py
@@ -433,7 +433,10 @@ def _persist_oauth_credentials(
 
     creds.access_token = authed_user["access_token"]
     creds.refresh_token = authed_user.get("refresh_token")
-    creds.scopes = authed_user.get("scope", "").split()
+    # Slack returns granted scopes comma-separated (e.g. "channels:history,users:read").
+    # Splitting on whitespace collapsed them into a single bogus element, so any
+    # per-scope check (e.g. "channels:history" in creds.scopes) always failed.
+    creds.scopes = [s for s in authed_user.get("scope", "").split(",") if s]
     creds.token_expires_at = token_expires_at
     creds.slack_user_id = authed_user.get("id")
 

--- a/tests/memory/api/test_slack.py
+++ b/tests/memory/api/test_slack.py
@@ -614,7 +614,7 @@ def test_callback_happy_path_creates_credentials_with_slack_app_id(
             team_id="T0123ABCDE",
             access_token="xoxp-test-access",
             refresh_token="xoxr-test-refresh",
-            scope="channels:history,chat:write",
+            scope="channels:history,users:read",
             id="U_TESTUSER",
             expires_in=3600,
         )
@@ -636,6 +636,10 @@ def test_callback_happy_path_creates_credentials_with_slack_app_id(
     assert creds is not None
     assert creds.access_token == "xoxp-test-access"
     assert creds.slack_app_id == authorized_slack_app.id
+    # Slack comma-separates granted scopes; they must be stored as distinct
+    # elements (a whitespace split collapsed them into one bogus string, so
+    # `"channels:history" in creds.scopes` was always False).
+    assert creds.scopes == ["channels:history", "users:read"]
 
 
 def test_callback_html_response_uses_json_dumps_for_slack_app_id(


### PR DESCRIPTION
Found doing a full Slack workspace setup end to end against a fresh instance. Two genuine bugs blocked/degraded setup, plus a wizard dead-end.

## Bugs

1. **Bot scope in the OAuth authorize URL blocks install.** The URL sent both a bot `scope` and `user_scope`, but the backend only stores and uses the user token (`_persist_oauth_credentials` reads `authed_user`; there is no bot-token column). Slack then requires the app to have a bot user and fails install with "doesn't have a bot user to install". Fixed by requesting `user_scope` only.

2. **Granted scopes parsed on whitespace, not comma.** Slack returns `scope` comma-separated (`"channels:history,users:read"`). `.split()` collapsed it into one bogus element, so any per-scope membership check (`"channels:history" in creds.scopes`) was always false. Fixed with `.split(",")`.

## Robustness

3. **Resumable setup wizard.** A half-configured draft app was a dead end: reopening the wizard looped back through already-completed OAuth with no path to the remaining steps. Now it starts at the first unfinished step (from the `client_secret` / `authorized` / `signing_secret` flags) and re-fetches the wizard nonce on resume; the Sources panel surfaces a "Finish setup" entry for apps not yet live.

Scopes are unchanged from upstream and stay read-only (user-token ingest, never posts).

## Docs / tests

- README: a short Slack setup runbook with the gotchas above.
- Tests: authorize URL carries `user_scope` and no bot `scope`; granted scopes parse on comma.

All frontend and backend Slack tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
